### PR TITLE
TDI-35766: skip docker plugin execution on skipITs.

### DIFF
--- a/components-splunk/pom.xml
+++ b/components-splunk/pom.xml
@@ -158,6 +158,7 @@
 							<goal>start</goal>
 						</goals>
 						<configuration>
+							<skip>${skipITs}</skip>
 							<images>
 								<image>
 									<name>dchmyga/splunk</name>
@@ -186,6 +187,9 @@
 						<goals>
 							<goal>stop</goal>
 						</goals>
+						<configuration>
+							<skip>${skipITs}</skip>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
if we skip integration tests we don't need docker plugin execution on pre-integration-test and post-integration-test phase. Used skipITs as the parameter for skipping plugin execution.