### PR TITLE
TCOMP-202 Added display names for common returns properties

### DIFF
--- a/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
+++ b/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
@@ -30,17 +30,6 @@ import org.talend.daikon.properties.property.Property;
  */
 
 public class ComponentPropertiesImpl extends PropertiesImpl implements ComponentProperties {
-    
-    /**
-     * Return properties names
-     */
-    public static final String ERROR_MESSAGE_NAME = "ERROR_MESSAGE";
-
-    public static final String NB_LINE_NAME = "NB_LINE";
-
-    public static final String NB_SUCCESS_NAME = "NB_SUCCESS";
-
-    public static final String NB_REJECT_NAME = "NB_REJECT";
 
     /**
      * A special property for the values that a component returns. If this is used, this will be a {@link Property} that

--- a/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
+++ b/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
@@ -30,6 +30,17 @@ import org.talend.daikon.properties.property.Property;
  */
 
 public class ComponentPropertiesImpl extends PropertiesImpl implements ComponentProperties {
+    
+    /**
+     * Return properties names
+     */
+    public static final String ERROR_MESSAGE_NAME = "ERROR_MESSAGE";
+
+    public static final String NB_LINE_NAME = "NB_LINE";
+
+    public static final String NB_SUCCESS_NAME = "NB_SUCCESS";
+
+    public static final String NB_REJECT_NAME = "NB_REJECT";
 
     /**
      * A special property for the values that a component returns. If this is used, this will be a {@link Property} that

--- a/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertyFactory.java
+++ b/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertyFactory.java
@@ -29,6 +29,17 @@ public class ComponentPropertyFactory {
      * Name of the special Returns property.
      */
     public static final String RETURNS = "returns";
+    
+    /**
+     * Return properties names
+     */
+    public static final String ERROR_MESSAGE_NAME = "ERROR_MESSAGE";
+
+    public static final String NB_LINE_NAME = "NB_LINE";
+
+    public static final String NB_SUCCESS_NAME = "NB_SUCCESS";
+
+    public static final String NB_REJECT_NAME = "NB_REJECT";
 
     /**
      * Used if there are returns to set the "returns" property with a {@link Property} that contains the returns

--- a/components-api/src/main/resources/org/talend/components/api/properties/ComponentPropertiesImpl.properties
+++ b/components-api/src/main/resources/org/talend/components/api/properties/ComponentPropertiesImpl.properties
@@ -1,1 +1,5 @@
 property.returns.displayName=Returns property
+property.ERROR_MESSAGE.displayName=Error Message
+property.NB_LINE.displayName=Number of line
+property.NB_SUCCESS.displayName=Number of success
+property.NB_REJECT.displayName=Number of reject

--- a/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
+++ b/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
@@ -13,6 +13,7 @@
 package org.talend.components.api.properties;
 
 import static org.junit.Assert.*;
+import static org.talend.components.api.properties.ComponentPropertyFactory.*;
 
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.junit.Before;

--- a/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
+++ b/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
@@ -35,7 +35,7 @@ public class ComponentPropertiesTest {
         }
     }
 
-    private final class NestedProperty extends ComponentPropertiesImpl{
+    private final class NestedProperty extends ComponentPropertiesImpl {
 
         public Property three = PropertyFactory.newString("three");
 
@@ -50,7 +50,7 @@ public class ComponentPropertiesTest {
         }
     }
 
-    private final class ComponentPropertiesTestClass extends ComponentPropertiesImpl{
+    private final class ComponentPropertiesTestClass extends ComponentPropertiesImpl {
 
         public Property one = PropertyFactory.newString("one");
 
@@ -63,6 +63,25 @@ public class ComponentPropertiesTest {
         public ComponentPropertiesTestClass(String name) {
             super(name);
         }
+    }
+    
+    /**
+     * Test class for {@link ComponentPropertiesTest#testReturnPropertiesDisplayName()},
+     * which contains common returns properties
+     */
+    private final class WithCommonReturnsProperties extends ComponentPropertiesImpl {
+
+        public Property<Integer> NB_LINE = ComponentPropertyFactory.newReturnProperty(getReturns(), PropertyFactory.newInteger(NB_LINE_NAME));
+        
+        public Property<Integer> NB_SUCCESS = ComponentPropertyFactory.newReturnProperty(getReturns(), PropertyFactory.newInteger(NB_SUCCESS_NAME));
+        
+        public Property<Integer> NB_REJECT = ComponentPropertyFactory.newReturnProperty(getReturns(), PropertyFactory.newInteger(NB_REJECT_NAME));
+        
+        public Property<Integer> ERROR_MESSAGE = ComponentPropertyFactory.newReturnProperty(getReturns(), PropertyFactory.newInteger(ERROR_MESSAGE_NAME));
+        
+        public WithCommonReturnsProperties(String name) {
+            super(name);
+        }        
     }
 
     ComponentPropertiesTestClass foo;
@@ -100,5 +119,19 @@ public class ComponentPropertiesTest {
         assertEquals("XYZ", foo.two.four.value.getValue());
         // check that instance have not changed, that only the values have been copied
         assertEquals(oldProp, foo.two.four);
+    }
+    
+    /**
+     * Checks display names for common returns properties are correctly set in ComponentPropertiesImpl.properties
+     */
+    @Test
+    public void testReturnPropertiesDisplayName() {
+        WithCommonReturnsProperties properties = new WithCommonReturnsProperties("foo");
+        properties.init();
+
+        assertEquals("Number of line", properties.NB_LINE.getDisplayName());
+        assertEquals("Number of success", properties.NB_SUCCESS.getDisplayName());
+        assertEquals("Number of reject", properties.NB_REJECT.getDisplayName());
+        assertEquals("Error Message", properties.ERROR_MESSAGE.getDisplayName());
     }
 }


### PR DESCRIPTION
WIP

https://jira.talendforge.org/browse/TCOMP-202

Also return properties display names  should be removed from all components. But currently I can't check it in Studio, because of old component-api version in Studio (0.11.0)