### PR TITLE
TDI-35987: Hide "Use HTTP Chunked" for tSalesforceInput Bulk Query

### DIFF
--- a/components-salesforce/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
+++ b/components-salesforce/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
@@ -104,8 +104,10 @@ public class TSalesforceInputProperties extends SalesforceConnectionModuleProper
             form.getWidget(normalizeDelimiter.getName()).setHidden(isBulkQuery);
             form.getWidget(columnNameDelimiter.getName()).setHidden(isBulkQuery);
             form.getWidget(batchSize.getName()).setHidden(isBulkQuery);
+
+            connection.bulkConnection.setValue(isBulkQuery);
+            connection.afterBulkConnection();
             form.getChildForm(connection.getName()).getWidget(connection.bulkConnection.getName()).setHidden(true);
-            form.getChildForm(connection.getName()).getWidget(connection.timeout.getName()).setHidden(isBulkQuery);
         }
     }
 

--- a/components-salesforce/src/test/java/org/talend/components/salesforce/SalesforceComponentTestIT.java
+++ b/components-salesforce/src/test/java/org/talend/components/salesforce/SalesforceComponentTestIT.java
@@ -12,14 +12,10 @@
 // ============================================================================
 package org.talend.components.salesforce;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -56,7 +52,6 @@ import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.service.Repository;
 import org.talend.daikon.properties.test.PropertiesTestUtils;
-import org.talend.daikon.serialize.SerializerDeserializer.Deserialized;
 
 public class SalesforceComponentTestIT extends SalesforceTestBase {
 
@@ -107,6 +102,30 @@ public class SalesforceComponentTestIT extends SalesforceTestBase {
         assertEquals(2, props.queryMode.getPossibleValues().size());
         Property[] returns = new TSalesforceInputDefinition().getReturnProperties();
         assertEquals(ComponentDefinition.RETURN_TOTAL_RECORD_COUNT, returns[0].getName());
+
+        // Default query mode
+        Form queryAdvancedForm = props.getForm(Form.ADVANCED);
+        assertTrue(queryAdvancedForm.getChildForm(props.connection.getName()).getWidget(props.connection.bulkConnection.getName())
+                .isHidden());
+        assertFalse(queryAdvancedForm.getWidget(props.normalizeDelimiter.getName()).isHidden());
+        assertFalse(queryAdvancedForm.getWidget(props.columnNameDelimiter.getName()).isHidden());
+        assertFalse(queryAdvancedForm.getChildForm(props.connection.getName()).getWidget(props.connection.httpChunked.getName())
+                .isHidden());
+        assertTrue(queryAdvancedForm.getChildForm(props.connection.getName())
+                .getWidget(props.connection.httpTraceMessage.getName()).isHidden());
+        // Change to bulk query mode
+        props.queryMode.setValue(TSalesforceInputProperties.QueryMode.Bulk);
+        props.afterQueryMode();
+
+        Form bulkQueryAdvancedForm = props.getForm(Form.ADVANCED);
+        assertTrue(bulkQueryAdvancedForm.getWidget(props.normalizeDelimiter.getName()).isHidden());
+        assertTrue(bulkQueryAdvancedForm.getWidget(props.columnNameDelimiter.getName()).isHidden());
+        assertTrue(bulkQueryAdvancedForm.getChildForm(props.connection.getName())
+                .getWidget(props.connection.httpChunked.getName()).isHidden());
+        assertFalse(bulkQueryAdvancedForm.getChildForm(props.connection.getName())
+                .getWidget(props.connection.httpTraceMessage.getName()).isHidden());
+        assertTrue(bulkQueryAdvancedForm.getChildForm(props.connection.getName())
+                .getWidget(props.connection.bulkConnection.getName()).isHidden());
     }
 
     static class RepoProps {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-35987

Because the query mode in tSalesforceInput can control "bulk connection" or not.
So we can set the value of bulkConnection based on query mode.