### PR TITLE
Output stream usage fixes

### DIFF
--- a/components-dataprep/src/main/java/org/talend/components/dataprep/connection/DataPrepConnectionHandler.java
+++ b/components-dataprep/src/main/java/org/talend/components/dataprep/connection/DataPrepConnectionHandler.java
@@ -56,6 +56,7 @@ public class DataPrepConnectionHandler {
         this.login = login;
         this.pass = pass;
         this.dataSetName = dataSetName;
+        LOGGER.debug("Url: {}", url);
     }
 
     public HttpResponse connect() throws IOException {
@@ -122,6 +123,7 @@ public class DataPrepConnectionHandler {
         urlConnection.setRequestMethod("POST");
         urlConnection.setRequestProperty(CONTENT_TYPE, TEXT_PLAIN);
         urlConnection.setDoOutput(true);
+        urlConnection.connect();
         return urlConnection.getOutputStream();
     }
 
@@ -178,5 +180,22 @@ public class DataPrepConnectionHandler {
         }
 
         return metaData.getColumns();
+    }
+
+    /**
+     * Close the resources used to send data to Data Prep server. This method also performs all necessary flush calls.
+     */
+    public void close() {
+        try {
+            LOGGER.debug("urlConnection = " + urlConnection);
+            LOGGER.debug("Response code: {} ", urlConnection.getResponseCode());
+            LOGGER.debug("Response message: {} ", urlConnection.getResponseMessage());
+            urlConnection.disconnect();
+            final OutputStream outputStream = urlConnection.getOutputStream();
+            outputStream.flush();
+            outputStream.close();
+        } catch (IOException e) {
+            LOGGER.error("Unable to close connection to {}.", url, e);
+        }
     }
 }

--- a/components-dataprep/src/main/java/org/talend/components/dataprep/runtime/DataSetWriter.java
+++ b/components-dataprep/src/main/java/org/talend/components/dataprep/runtime/DataSetWriter.java
@@ -113,7 +113,6 @@ public class DataSetWriter implements Writer<Result> {
         row.append("\n");
         LOGGER.debug("Row data: {}", row);
         outputStream.write(row.toString().getBytes());
-        outputStream.flush();
         result.totalCount++;
     }
 
@@ -122,6 +121,7 @@ public class DataSetWriter implements Writer<Result> {
         if (!isLiveDataSet()) {
             connectionHandler.logout();
         }
+        connectionHandler.close();
         result.successCount = result.totalCount;
         return result;
     }

--- a/components-dataprep/src/test/java/org/talend/components/dataprep/connection/DataPrepConnectionHandlerTest.java
+++ b/components-dataprep/src/test/java/org/talend/components/dataprep/connection/DataPrepConnectionHandlerTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 public class DataPrepConnectionHandlerTest {
 
     @Autowired
-    DataPrepServerMock dataPrepServerMock;
+    private DataPrepServerMock dataPrepServerMock;
 
     private DataPrepConnectionHandler connectionHandler;
 
@@ -117,6 +117,7 @@ public class DataPrepConnectionHandlerTest {
         //Exception shouldn't be thrown.
         connectionHandler.createInLiveDataSetMode().write("Hello".getBytes());
         Assert.assertEquals(200, returnStatusCode(connectionHandler.logout()));
+        Assert.assertEquals("Hello", dataPrepServerMock.getLastReceivedLiveDataSetContent());
     }
 
     @Test

--- a/components-dataprep/src/test/java/org/talend/components/dataprep/connection/DataPrepServerMock.java
+++ b/components-dataprep/src/test/java/org/talend/components/dataprep/connection/DataPrepServerMock.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -24,8 +25,11 @@ public class DataPrepServerMock {
     private String lastTag;
 
     private String lastName;
+    
+    private String lastReceivedLiveDataSetContent;
 
     public void clear() {
+        lastReceivedLiveDataSetContent = null;
         lastTag = null;
         lastName = null;
     }
@@ -103,8 +107,12 @@ public class DataPrepServerMock {
     @RequestMapping(value = "/", method = RequestMethod.POST)
     public ResponseEntity createInLiveDataSet(InputStream inputStream) throws IOException {
         checkNotNull(inputStream);
-        ByteStreams.toByteArray(inputStream);
+        lastReceivedLiveDataSetContent = IOUtils.toString(inputStream);
         return new ResponseEntity(HttpStatus.OK);
+    }
+
+    String getLastReceivedLiveDataSetContent() {
+        return lastReceivedLiveDataSetContent;
     }
 
     String getLastTag() {


### PR DESCRIPTION
* Adds close() method for DataPrepConnectionHandler responsible of flush & close.
* Don't flush at every line for better efficiency.
* Update unit test so test now ensure all content is send to service.