### PR TITLE
update the PR review process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,10 @@ Here is the workflow for pull requests.
   * **Can be merged after rework**, The review is fine but requires some minor (cosmetic) adjustments that do not need to be reviewed again. The PR is then assigned back to the PR's creator for some minor work. Once the work is done the creator can directly Merge and Squash it without the need of any review. If the creator does not have the right to do so, it will assign it back to the Reviewer after rework so that it can be merged.
   * **Rework Required**, the review added some comments that need work to be done and another review is required after. The reviewer assigns it to the PR creator.
 7. if **Rework Required** once assigne to the PR creator, he/she has to make the required changes, then assign it back to the initial Reviewer and set the label **Need review** again. Then back to step 5.
+
+Here are the label definitions for this workflow (label name : color code) :
+* Need review                : #fef2c0
+* Can be merged after rework : #c2e0c6
+* Can be merged              : #0e8a16
+* Reviewing                  : #fbca04
+* Rework required            : #1d76db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,11 @@ Here is the workflow for pull requests.
    
    The first green check indicates that the branch build is fine, the label "Merged build passed" indicates that the merge to master build is fine. 
 2. If you receive an email notification that there is a build issue please fix it. No PR will be reviewed if the build has failed.
-3. The components owners will then identify who is going to do the review and then assign it. The reviewer will recieve an automatic mail notification.
-4. Once the reviewer starts the review, he/she should set the label **Reviewing**.
-5. Once the review is done, the reviewer has 3 alternatives states:
+3. Once the branch build and the PR merged build are OK, and you need your PR to be reviewed you must use the label **Need review**. If your PR is still a work in progress, do not use any label but this means no review will be performed.
+4. The components owners will then identify who is going to do the review and then assign it. The reviewer will recieve an automatic mail notification.
+5. Once the reviewer starts the review, he/she should set the label **Reviewing**.
+6. Once the review is done, the reviewer has 3 alternatives states:
   * **Can be merged**, the reviewer is happy with the PR so the PR can be merged. The reviewer should set the label *Can be Merged* and then Merge and Squash the PR.
   * **Can be merged after rework**, The review is fine but requires some minor (cosmetic) adjustments that do not need to be reviewed again. The PR is then assigned back to the PR's creator for some minor work. Once the work is done the creator can directly Merge and Squash it without the need of any review. If the creator does not have the right to do so, it will assign it back to the Reviewer after rework so that it can be merged.
   * **Rework Required**, the review added some comments that need work to be done and another review is required after. The reviewer assigns it to the PR creator.
-6. if **Rework Required** once assigne to the PR creator, he/she has to make the required changes and then assign it back to the initial Reviewer. Then back to step 4.
+7. if **Rework Required** once assigne to the PR creator, he/she has to make the required changes, then assign it back to the initial Reviewer and set the label **Need review** again. Then back to step 5.


### PR DESCRIPTION
I realized that some PR may not be ready for review when created and the current process for reviewing the PR does not cope with this use case.
This is why I suggest to update the process by adding a new label **Need review**.
Please @pteyssier @gonchar-ivan can you have a look and let me know what you think about this.
I will eventually present it to the TAB because it seems to be working well I think.
