### PR TITLE
Feature/6.3/tcomp 230 flow variables definition. Helper method

### DIFF
--- a/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
+++ b/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
@@ -192,5 +192,26 @@ public abstract class AbstractComponentDefinition extends AbstractTopLevelDefini
         }
         return namedThings;
     }
+    
+    /**
+     * Types (availability) of Return properties
+     * This type means in what point of Job execution Return variable is available.
+     * AFTER variable is available after all records are processed in current flow
+     * FLOW variable is available after each record is processed in current flow
+     */
+    protected static enum ReturnType {
+        AFTER,
+        FLOW
+    }
+    
+    /**
+     * Sets {@link ReturnType} of Return property.
+     * 
+     * @param property Return property, which type to be set
+     * @param type {@link ReturnType}
+     */
+    protected static void setReturnType(Property<?> property, ReturnType type) {
+        property.setTaggedValue("AVAILABILITY", type.toString());
+    }
 
 }


### PR DESCRIPTION
Related to https://jira.talendforge.org/browse/TCOMP-230

We already have support of After Return variables (We call them simply Return values/properties).
However Return values are not only After variables. There is another type of Return values - Flow variables. They are often used in Studio components.

This PR adds helper method to set type (availability) of return property. Type could be AFTER or FLOW.
