### PR TITLE
TDI-37479 Added percent type schema infering

### DIFF
--- a/components-salesforce/src/main/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistry.java
+++ b/components-salesforce/src/main/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistry.java
@@ -166,6 +166,9 @@ public class SalesforceAvroRegistry extends AvroRegistry {
         case _double:
             base = AvroUtils._double();
             break;
+        case percent:
+            base = AvroUtils._double();
+            break;
         case _int:
             base = AvroUtils._int();
             break;

--- a/components-salesforce/src/test/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistryTest.java
+++ b/components-salesforce/src/test/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistryTest.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
 import org.junit.Test;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
@@ -174,5 +175,21 @@ public class SalesforceAvroRegistryTest {
         assertThat(s.getType(), is(Schema.Type.STRING));
         assertThat(s.getProp(SchemaConstants.JAVA_CLASS_FLAG), is(BigDecimal.class.getCanonicalName()));
         // assertThat(s.getLogicalType(), is((LogicalType) LogicalTypes.decimal(8, 5)));
+    }
+    
+    /**
+     * Tests {@link SalesforceAvroRegistry#inferSchema(Object)} returns {@link Schema} of type {@link Type#DOUBLE},
+     * when percent Field is passed
+     * 
+     * This test-case related to https://jira.talendforge.org/browse/TDI-37479 bug
+     */
+    @Test
+    public void testInferSchemaFieldPercent() {
+        Field percentField = new Field();
+        percentField.setType(FieldType.percent);
+
+        Schema schema = sRegistry.inferSchema(percentField);
+        Schema.Type actualType = schema.getType();
+        assertThat(actualType, is(Schema.Type.DOUBLE));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
SalesforceAvroRegistry returns String schema for Percent Salesforce specific data type


**What is the new behavior?**
SalesforceAvroRegistry returns Double schema for Percent Salesforce specific data type


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Related to https://jira.talendforge.org/browse/TDI-37479
