### PR TITLE
fix (TDI-37671): wrong configuration in tfileoutputdelimited definition

### DIFF
--- a/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedDefinition.java
+++ b/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedDefinition.java
@@ -30,11 +30,6 @@ public abstract class FileDelimitedDefinition extends AbstractComponentDefinitio
     }
 
     @Override
-    public boolean isSchemaAutoPropagate() {
-        return true;
-    }
-
-    @Override
     public Class<? extends ComponentProperties>[] getNestedCompatibleComponentPropertiesClass() {
         return new Class[] { FileDelimitedProperties.class };
     }

--- a/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedDefinition.java
+++ b/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedDefinition.java
@@ -27,11 +27,6 @@ public class TFileInputDelimitedDefinition extends FileDelimitedDefinition {
     }
 
     @Override
-    public boolean isSchemaAutoPropagate() {
-        return false;
-    }
-
-    @Override
     public boolean isConditionalInputs() {
         return true;
     }

--- a/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedDefinition.java
+++ b/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedDefinition.java
@@ -28,17 +28,12 @@ public class TFileOutputDelimitedDefinition extends FileDelimitedDefinition {
 
     @Override
     public boolean isSchemaAutoPropagate() {
-        return false;
-    }
-
-    @Override
-    public boolean isConditionalInputs() {
         return true;
     }
 
     @Override
     public String getPartitioning() {
-        return AUTO;
+        return NONE;
     }
 
     @Override

--- a/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestIT.java
+++ b/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestIT.java
@@ -7,13 +7,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.talend.components.api.component.AbstractComponentDefinition;
 import org.talend.components.api.component.ComponentDefinition;
+import org.talend.components.api.component.ConnectorTopology;
 import org.talend.components.api.properties.ComponentProperties;
 import org.talend.components.api.test.ComponentTestUtils;
 import org.talend.components.common.EncodingTypeProperties;
@@ -39,15 +42,28 @@ public class FileDelimitedTestIT extends FileDelimitedTestBasic {
     }
 
     @Test
-    public void testFamily() {
+    public void testComponentDefinition() {
         ComponentDefinition cdInput = getComponentService().getComponentDefinition(TFileInputDelimitedDefinition.COMPONENT_NAME);
         assertEquals(1, cdInput.getFamilies().length);
         assertEquals("File/Input", cdInput.getFamilies()[0]);
+        assertFalse(cdInput.isDataAutoPropagate());
+        assertFalse(cdInput.isSchemaAutoPropagate());
+        assertTrue(cdInput.isConditionalInputs());
+        assertTrue(cdInput.isStartable());
+        assertNull(cdInput.getPartitioning());
+        assertEquals(EnumSet.of(ConnectorTopology.OUTGOING), cdInput.getSupportedConnectorTopologies());
 
         ComponentDefinition cdOutput = getComponentService()
                 .getComponentDefinition(TFileOutputDelimitedDefinition.COMPONENT_NAME);
         assertEquals(1, cdOutput.getFamilies().length);
         assertEquals("File/Output", cdOutput.getFamilies()[0]);
+        assertTrue(cdOutput.isSchemaAutoPropagate());
+        assertFalse(cdOutput.isConditionalInputs());
+        assertFalse(cdInput.isDataAutoPropagate());
+        assertFalse(cdOutput.isStartable());
+        assertEquals(AbstractComponentDefinition.NONE, cdOutput.getPartitioning());
+        assertEquals(EnumSet.of(ConnectorTopology.INCOMING, ConnectorTopology.INCOMING_AND_OUTGOING),
+                cdOutput.getSupportedConnectorTopologies());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

1. Schema can't propagate tFileOutputDelimited automatically.
_isSchemaAutoPropagate()_ for tFileOutputDelimited should return true.
2. Based on old framework configuration xml. For tFileOutputDelimited :
_isConditionalInputs()_ should return _false_ and _getPartitioning()_ should return **NONE** not **AUTO**

**What is the new behavior?**

Fix above issue and add unit test.


**Does this PR introduce a breaking change?**

- [x] No
