### PR TITLE
fix(TCOMP-322): change jackson-databind scope from compile to test ex…

### DIFF
--- a/components-dataprep/pom.xml
+++ b/components-dataprep/pom.xml
@@ -78,6 +78,7 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.5.3</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -30,7 +30,7 @@
 	<distributionManagement>
 		<snapshotRepository>
 			<id>talend_nexus_deployment</id>
-			<url>${talend_snapshots}</url>
+			<url>${talend_snapshots_deployment}</url>
 		</snapshotRepository>
 		<repository>
 			<id>talend_nexus_deployment</id>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -113,7 +113,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<scope>test</scope>
+				<version>2.5.3</version>
 			</dependency>
 
 		</dependencies>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -110,6 +110,11 @@
 				<artifactId>avro</artifactId>
 				<version>1.8.0</version>
 			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<scope>test</scope>
+			</dependency>
 
 		</dependencies>
 	</dependencyManagement>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -104,7 +104,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
 	<build>
 		<plugins>
 			<plugin>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -104,6 +104,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

com.fasterxml.jackson.core:jackson-databind:jar:2.4.6 has compile scope.
Studio requires this artifact. But it is not required in compile/runtime

**What is the new behavior?**

com.fasterxml.jackson.core:jackson-databind:jar:2.4.6 will have test scope.
Dataprep and services-rest are exceptions, because they require this artifact in compile scope

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Related to https://jira.talendforge.org/browse/TCOMP-322
