### PR TITLE
fix (TDI-37593): tfileinputdelimited no-csv mode wrong nb line count

### DIFF
--- a/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedAdaptorFactory.java
+++ b/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedAdaptorFactory.java
@@ -1,5 +1,7 @@
 package org.talend.components.filedelimited.runtime;
 
+import static org.talend.components.filedelimited.tfileinputdelimited.TFileInputDelimitedProperties.FIELD_ERROR_MESSAGE;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,6 @@ public class DelimitedAdaptorFactory implements IndexedRecordConverter<String[],
         }
     }
 
-
     private class DelimitedIndexedRecord implements IndexedRecord {
 
         String[] values;
@@ -109,7 +110,7 @@ public class DelimitedAdaptorFactory implements IndexedRecordConverter<String[],
                         throw e;
                     } else {
                         Map<String, Object> resultMessage = new HashMap<String, Object>();
-                        resultMessage.put("errorMessage", e.getMessage());
+                        resultMessage.put(FIELD_ERROR_MESSAGE, e.getMessage());
                         resultMessage.put("talend_record", this);
                         throw new DataRejectException(resultMessage);
                     }

--- a/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedReader.java
+++ b/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedReader.java
@@ -50,7 +50,9 @@ public class DelimitedReader extends FileDelimitedReader {
                 startAble = advance();
             }
         }
-
+        if (startAble) {
+            dataCount++;
+        }
         return startAble;
     }
 
@@ -78,7 +80,9 @@ public class DelimitedReader extends FileDelimitedReader {
                 isContinue = advance();
             }
         }
-
+        if (isContinue) {
+            dataCount++;
+        }
         return isContinue;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
The number lines count of tFileInputDelimited no-csv mode is incorrect


**What is the new behavior?**
fix with correct count


**Does this PR introduce a breaking change?**

- [x] No

