### PR TITLE
fix(TCOMP-367): Add display name for tJDBCDatastore

### DIFF
--- a/components-jdbc/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreDefinition.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreDefinition.java
@@ -53,4 +53,9 @@ public class JDBCDatastoreDefinition extends SimpleNamedThing implements Datasto
         return JDBCDatastoreProperties.class;
     }
 
+    @Override
+    public String getDisplayName() {
+        return getI18nMessage("datastore." + getName() + I18N_DISPLAY_NAME_SUFFIX);
+    }
+
 }

--- a/components-jdbc/src/main/resources/org/talend/components/jdbc/datastore/messages.properties
+++ b/components-jdbc/src/main/resources/org/talend/components/jdbc/datastore/messages.properties
@@ -1,4 +1,5 @@
 component.JDBCDatastore.title=JDBC Data Store
+component.JDBCDatastore.displayName=Database
 
 property.dbTypes.displayName=DB Type
 property.jdbcUrl.displayName=JDBC URL

--- a/components-jdbc/src/main/resources/org/talend/components/jdbc/datastore/messages.properties
+++ b/components-jdbc/src/main/resources/org/talend/components/jdbc/datastore/messages.properties
@@ -1,5 +1,5 @@
 component.JDBCDatastore.title=JDBC Data Store
-component.JDBCDatastore.displayName=Database
+datastore.JDBCDatastore.displayName=Database
 
 property.dbTypes.displayName=DB Type
 property.jdbcUrl.displayName=JDBC URL


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TCOMP-367


**What is the new behavior?**
add the lost display name in the message file for data store


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:
https://jira.talendforge.org/browse/TCOMP-367
