### PR TITLE
fix(TCOMP-379): fix the getSample method for JDBCDatasetRuntime, make it can works when no schema found in the dataset properties

### DIFF
--- a/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
@@ -23,7 +23,6 @@ import org.talend.components.api.properties.ComponentProperties;
 import org.talend.components.common.SchemaProperties;
 import org.talend.components.jdbc.module.JDBCConnectionModule;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
-import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.presentation.Form;
 
@@ -37,26 +36,6 @@ public class CommonUtils {
      */
     public static Schema getSchema(SchemaProperties schema) {
         return schema.schema.getValue();
-    }
-
-    /**
-     * check if schema is valid before using it. If valid, return true, if not, return false.
-     * 
-     * @param schema
-     * @return
-     */
-    public static boolean isSchemaValid(Schema schema) {
-        if (schema == null) {
-            return false;
-        }
-
-        if (AvroUtils.isIncludeAllFields(schema)) {
-            return true;
-        }
-
-        List<Schema.Field> fields = schema.getFields();
-
-        return fields != null && !fields.isEmpty();
     }
 
     /**

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
@@ -45,7 +45,7 @@ public class CommonUtils {
      * @param schema
      * @return
      */
-    public static boolean IsSchemaValid(Schema schema) {
+    public static boolean isSchemaValid(Schema schema) {
         if (schema == null) {
             return false;
         }

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/CommonUtils.java
@@ -23,6 +23,7 @@ import org.talend.components.api.properties.ComponentProperties;
 import org.talend.components.common.SchemaProperties;
 import org.talend.components.jdbc.module.JDBCConnectionModule;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
+import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.presentation.Form;
 
@@ -36,6 +37,26 @@ public class CommonUtils {
      */
     public static Schema getSchema(SchemaProperties schema) {
         return schema.schema.getValue();
+    }
+
+    /**
+     * check if schema is valid before using it. If valid, return true, if not, return false.
+     * 
+     * @param schema
+     * @return
+     */
+    public static boolean IsSchemaValid(Schema schema) {
+        if (schema == null) {
+            return false;
+        }
+
+        if (AvroUtils.isIncludeAllFields(schema)) {
+            return true;
+        }
+
+        List<Schema.Field> fields = schema.getFields();
+
+        return fields != null && !fields.isEmpty();
     }
 
     /**

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
@@ -74,7 +74,7 @@ public class JDBCDatasetProperties extends PropertiesImpl
         Form mainForm = CommonUtils.addForm(this, Form.MAIN);
         mainForm.addRow(sql);
 
-        mainForm.addRow(main.getForm(Form.REFERENCE));
+        // mainForm.addRow(main.getForm(Form.REFERENCE));
     }
 
     @Override

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
@@ -28,7 +28,6 @@ import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.api.exception.ComponentException;
 import org.talend.components.common.avro.JDBCAvroRegistry;
 import org.talend.components.common.avro.JDBCResultSetIndexedRecordConverter;
-import org.talend.components.jdbc.CommonUtils;
 import org.talend.components.jdbc.RuntimeSettingProvider;
 import org.talend.components.jdbc.runtime.JDBCSource;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
@@ -76,7 +75,7 @@ public class JDBCInputReader extends AbstractBoundedReader<IndexedRecord> {
             // querySchema = CommonUtils.getMainSchemaFromOutputConnector((ComponentProperties) properties);
             querySchema = setting.getSchema();
 
-            if (!CommonUtils.isSchemaValid(querySchema) || AvroUtils.isIncludeAllFields(querySchema)) {
+            if (AvroUtils.isSchemaEmpty(querySchema) || AvroUtils.isIncludeAllFields(querySchema)) {
                 /**
                  * the code above make the action different with the usage in studio,
                  * as in studio, we only use the design schema if no dynamic column exists.

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
@@ -28,6 +28,7 @@ import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.api.exception.ComponentException;
 import org.talend.components.common.avro.JDBCAvroRegistry;
 import org.talend.components.common.avro.JDBCResultSetIndexedRecordConverter;
+import org.talend.components.jdbc.CommonUtils;
 import org.talend.components.jdbc.RuntimeSettingProvider;
 import org.talend.components.jdbc.runtime.JDBCSource;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
@@ -75,7 +76,18 @@ public class JDBCInputReader extends AbstractBoundedReader<IndexedRecord> {
             // querySchema = CommonUtils.getMainSchemaFromOutputConnector((ComponentProperties) properties);
             querySchema = setting.getSchema();
 
-            if (AvroUtils.isIncludeAllFields(querySchema)) {
+            if (!CommonUtils.IsSchemaValid(querySchema) || AvroUtils.isIncludeAllFields(querySchema)) {
+                /**
+                 * the code above make the action different with the usage in studio,
+                 * as in studio, we only use the design schema if no dynamic column exists.
+                 * Here, we will use the runtime schema too when no valid design schema found,
+                 * it work for data set topic.
+                 * 
+                 * And another thing, the reader or other runtime execution object should be common,
+                 * and not depend on the platform, so should use the same action, so we use the same
+                 * reader for studio and dataprep(now for data store and set) execution platform. And
+                 * need more thinking about it.
+                 */
                 querySchema = JDBCAvroRegistry.get().inferSchema(resultSet.getMetaData());
             }
         }

--- a/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
+++ b/components-jdbc/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
@@ -76,7 +76,7 @@ public class JDBCInputReader extends AbstractBoundedReader<IndexedRecord> {
             // querySchema = CommonUtils.getMainSchemaFromOutputConnector((ComponentProperties) properties);
             querySchema = setting.getSchema();
 
-            if (!CommonUtils.IsSchemaValid(querySchema) || AvroUtils.isIncludeAllFields(querySchema)) {
+            if (!CommonUtils.isSchemaValid(querySchema) || AvroUtils.isIncludeAllFields(querySchema)) {
                 /**
                  * the code above make the action different with the usage in studio,
                  * as in studio, we only use the design schema if no dynamic column exists.

--- a/components-jdbc/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetTestIT.java
+++ b/components-jdbc/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetTestIT.java
@@ -44,7 +44,7 @@ public class JDBCDatasetTestIT {
 
     @Test
     public void testUpdateSchema() {
-        JDBCDatasetProperties dataset = createDatasetProperties();
+        JDBCDatasetProperties dataset = createDatasetProperties(true);
 
         Schema schema = dataset.main.schema.getValue();
 
@@ -54,7 +54,7 @@ public class JDBCDatasetTestIT {
 
     @Test
     public void testGetSchema() {
-        JDBCDatasetProperties dataset = createDatasetProperties();
+        JDBCDatasetProperties dataset = createDatasetProperties(false);
 
         JDBCDatasetRuntime runtime = new JDBCDatasetRuntime();
         runtime.initialize(null, dataset);
@@ -65,9 +65,18 @@ public class JDBCDatasetTestIT {
     }
 
     @Test
-    public void testGetSample() {
-        JDBCDatasetProperties dataset = createDatasetProperties();
+    public void testGetSampleWithValidDesignSchema() {
+        JDBCDatasetProperties dataset = createDatasetProperties(true);
+        getSampleAction(dataset);
+    }
 
+    @Test
+    public void testGetSampleWithoutDesignSchema() {
+        JDBCDatasetProperties dataset = createDatasetProperties(false);
+        getSampleAction(dataset);
+    }
+
+    private void getSampleAction(JDBCDatasetProperties dataset) {
         JDBCDatasetRuntime runtime = new JDBCDatasetRuntime();
         runtime.initialize(null, dataset);
         final IndexedRecord[] record = new IndexedRecord[1];
@@ -85,7 +94,7 @@ public class JDBCDatasetTestIT {
         Assert.assertEquals("wangwei", record[0].get(1));
     }
 
-    private JDBCDatasetProperties createDatasetProperties() {
+    private JDBCDatasetProperties createDatasetProperties(boolean updateSchema) {
         JDBCDatastoreDefinition def = new JDBCDatastoreDefinition();
         JDBCDatastoreProperties datastore = new JDBCDatastoreProperties("datastore");
 
@@ -99,7 +108,9 @@ public class JDBCDatasetTestIT {
         JDBCDatasetProperties dataset = (JDBCDatasetProperties) def.createDatasetProperties(datastore);
         dataset.sql.setValue(DBTestUtils.getSQL());
 
-        dataset.updateSchema();
+        if (updateSchema) {
+            dataset.updateSchema();
+        }
         return dataset;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TCOMP-379


**What is the new behavior?**



**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:
https://jira.talendforge.org/browse/TCOMP-379