### PR TITLE
feat(TDI-38344): Added tests for definition

### DIFF
--- a/components/components-netsuite/netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteComponentDefinition.java
+++ b/components/components-netsuite/netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteComponentDefinition.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.talend.components.api.component.AbstractComponentDefinition;
 import org.talend.components.api.component.runtime.DependenciesReader;
 import org.talend.components.api.component.runtime.ExecutionEngine;
@@ -100,7 +99,7 @@ public abstract class NetSuiteComponentDefinition extends AbstractComponentDefin
 
         NetSuiteConnectionProperties connectionProperties = properties.getConnectionProperties();
 
-        String endpointUrl = StringUtils.strip(connectionProperties.endpoint.getStringValue(), "\"");
+        String endpointUrl = connectionProperties.endpoint.getStringValue();
         String apiVersion = detectApiVersion(endpointUrl);
 
         String artifactId = MAVEN_ARTIFACT_ID.replace("${version}", apiVersion);

--- a/components/components-netsuite/netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputModuleProperties.java
+++ b/components/components-netsuite/netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputModuleProperties.java
@@ -78,22 +78,8 @@ public class NetSuiteInputModuleProperties extends NetSuiteModuleProperties {
     public ValidationResult afterModuleName() throws Exception {
         try {
             setupSchema();
-
-            SearchInfo searchSchema = getSearchInfo(moduleName.getValue());
-            List<String> fieldNames = new ArrayList<>(searchSchema.getFields().size());
-            for (SearchFieldInfo field : searchSchema.getFields()) {
-                fieldNames.add(field.getName());
-            }
-
-            searchQuery.field.setPossibleValues(fieldNames);
-            searchQuery.field.setValue(new ArrayList<String>());
-
-            searchQuery.operator.setPossibleValues(getSearchFieldOperators());
-            searchQuery.operator.setValue(new ArrayList<String>());
-
-            searchQuery.value1.setValue(new ArrayList<String>());
-            searchQuery.value2.setValue(new ArrayList<String>());
-
+            setupSearchSchema();
+            refreshLayout(getForm(Form.MAIN));
             return ValidationResult.OK;
 
         } catch (Exception ex) {
@@ -101,8 +87,31 @@ public class NetSuiteInputModuleProperties extends NetSuiteModuleProperties {
         }
     }
 
+    public void afterSearchQuery() {
+        refreshLayout(getForm(Form.MAIN));
+    }
+
     protected void setupSchema() {
         Schema schema = getSchema(moduleName.getStringValue());
         main.schema.setValue(schema);
+    }
+
+    protected void setupSearchSchema() {
+        SearchInfo searchSchema = getSearchInfo(moduleName.getValue());
+        List<String> fieldNames = new ArrayList<>(searchSchema.getFields().size());
+        for (SearchFieldInfo field : searchSchema.getFields()) {
+            fieldNames.add(field.getName());
+        }
+
+        searchQuery.field.setPossibleValues(fieldNames);
+        searchQuery.field.setValue(new ArrayList<String>());
+
+        searchQuery.operator.setPossibleValues(getSearchFieldOperators());
+        searchQuery.operator.setValue(new ArrayList<String>());
+
+        searchQuery.value1.setValue(new ArrayList<String>());
+        searchQuery.value2.setValue(new ArrayList<String>());
+
+        searchQuery.refreshLayout(searchQuery.getForm(Form.MAIN));
     }
 }

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteComponentTestBase.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteComponentTestBase.java
@@ -20,12 +20,13 @@ import javax.inject.Inject;
 
 import org.junit.Test;
 import org.talend.components.api.test.AbstractComponentTest2;
+import org.talend.components.netsuite.connection.NetSuiteConnectionDefinition;
 import org.talend.components.netsuite.input.NetSuiteInputDefinition;
 import org.talend.components.netsuite.output.NetSuiteOutputDefinition;
 import org.talend.daikon.definition.Definition;
 import org.talend.daikon.definition.service.DefinitionRegistryService;
 
-public class NetSuiteInputTestBase extends AbstractComponentTest2 {
+public class NetSuiteComponentTestBase extends AbstractComponentTest2 {
 
     @Inject DefinitionRegistryService defReg;
 
@@ -36,9 +37,11 @@ public class NetSuiteInputTestBase extends AbstractComponentTest2 {
 
     @Test
     public void componentHasBeenRegistered(){
-        assertThat(getDefinitionRegistry().getDefinitionsMapByType(Definition.class).get(NetSuiteInputDefinition.COMPONENT_NAME),
-                notNullValue());
-        assertThat(getDefinitionRegistry().getDefinitionsMapByType(Definition.class).get(NetSuiteOutputDefinition.COMPONENT_NAME),
-                notNullValue());
+        assertThat(getDefinitionRegistry().getDefinitionsMapByType(Definition.class)
+                .get(NetSuiteConnectionDefinition.COMPONENT_NAME), notNullValue());
+        assertThat(getDefinitionRegistry().getDefinitionsMapByType(Definition.class)
+                .get(NetSuiteInputDefinition.COMPONENT_NAME), notNullValue());
+        assertThat(getDefinitionRegistry().getDefinitionsMapByType(Definition.class)
+                .get(NetSuiteOutputDefinition.COMPONENT_NAME), notNullValue());
     }
 }

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteFamilyDefinitionTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteFamilyDefinitionTest.java
@@ -1,0 +1,59 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.talend.components.api.ComponentInstaller;
+import org.talend.components.netsuite.connection.NetSuiteConnectionDefinition;
+import org.talend.components.netsuite.input.NetSuiteInputDefinition;
+import org.talend.components.netsuite.output.NetSuiteOutputDefinition;
+
+/**
+ *
+ */
+public class NetSuiteFamilyDefinitionTest {
+
+    private NetSuiteFamilyDefinition familyDefinition = new NetSuiteFamilyDefinition();
+
+    private ComponentInstaller.ComponentFrameworkContext frameworkContext =
+            Mockito.mock(ComponentInstaller.ComponentFrameworkContext.class);
+
+    @Test
+    public void testName() {
+        assertEquals("NetSuite", familyDefinition.getName());
+    }
+
+    @Test
+    public void testDefinitions() {
+        assertThat(familyDefinition.getDefinitions(), Matchers.containsInAnyOrder(
+                Matchers.instanceOf(NetSuiteConnectionDefinition.class),
+                Matchers.instanceOf(NetSuiteInputDefinition.class),
+                Matchers.instanceOf(NetSuiteOutputDefinition.class)
+        ));
+    }
+
+    @Test
+    public void testInstall() {
+        familyDefinition.install(frameworkContext);
+        Mockito.verify(frameworkContext, times(1))
+                .registerComponentFamilyDefinition(any(NetSuiteFamilyDefinition.class));
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuitePropertiesTestBase.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuitePropertiesTestBase.java
@@ -1,0 +1,248 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.talend.components.netsuite.connection.NetSuiteConnectionProperties;
+import org.talend.components.netsuite.schema.SearchFieldInfo;
+import org.talend.components.netsuite.schema.SearchInfo;
+import org.talend.daikon.NamedThing;
+import org.talend.daikon.SimpleNamedThing;
+import org.talend.daikon.avro.AvroUtils;
+import org.talend.daikon.java8.Function;
+
+/**
+ *
+ */
+public abstract class NetSuitePropertiesTestBase {
+
+    public static void installMockRuntimeInvoker(MockRuntimeInvoker runtimeInvoker) {
+        NetSuiteComponentDefinition.setRuntimeInvoker(runtimeInvoker);
+    }
+
+    public static void installMockRuntime(NetSuiteRuntime runtime) {
+        installMockRuntimeInvoker(new MockRuntimeInvoker(runtime));
+    }
+
+    protected TestDataset createTestDataset1() {
+        TestDataset dataset = new TestDataset();
+
+        dataset.getRecordTypes().addAll(Arrays.<NamedThing>asList(
+                new SimpleNamedThing("Account"),
+                new SimpleNamedThing("Opportunity")
+        ));
+
+        dataset.getSearchableTypes().addAll(Arrays.<NamedThing>asList(
+                new SimpleNamedThing("Account"),
+                new SimpleNamedThing("Opportunity"),
+                new SimpleNamedThing("Transaction")
+        ));
+
+        dataset.getTypeSchemaMap().put("Account", SchemaBuilder.builder().record("Account")
+                .fields()
+                .name("AccountField1").type(AvroUtils._boolean()).noDefault()
+                .name("AccountField2").type(AvroUtils._string()).noDefault()
+                .name("AccountField3").type(AvroUtils._logicalTimestamp()).noDefault()
+                .endRecord()
+        );
+        dataset.getTypeSchemaMap().put("Opportunity", SchemaBuilder.builder().record("Opportunity")
+                .fields()
+                .name("OpportunityField1").type(AvroUtils._boolean()).noDefault()
+                .name("OpportunityField2").type(AvroUtils._double()).noDefault()
+                .name("OpportunityField3").type(AvroUtils._logicalTimestamp()).noDefault()
+                .endRecord()
+        );
+        dataset.getTypeSchemaMap().put("RecordRef", SchemaBuilder.builder().record("RecordRef")
+                .fields()
+                .name("InternalId").type(AvroUtils._boolean()).noDefault()
+                .name("Type").type(AvroUtils._string()).noDefault()
+                .endRecord()
+        );
+
+        dataset.getSearchOperators().addAll(Arrays.<NamedThing>asList(
+                new SimpleNamedThing("Boolean"),
+                new SimpleNamedThing("Date.onOrAfter"),
+                new SimpleNamedThing("String.contains")
+        ));
+
+        dataset.getSearchInfoMap().put("Account",
+            new SearchInfo("Account", Arrays.asList(
+                    new SearchFieldInfo("AccountField1", Boolean.class),
+                    new SearchFieldInfo("AccountField2", String.class),
+                    new SearchFieldInfo("AccountField3", XMLGregorianCalendar.class)
+            ))
+        );
+        dataset.getSearchInfoMap().put("Opportunity",
+                new SearchInfo("Opportunity", Arrays.asList(
+                        new SearchFieldInfo("OpportunityField1", Boolean.class),
+                        new SearchFieldInfo("OpportunityField2", Double.class),
+                        new SearchFieldInfo("OpportunityField3", XMLGregorianCalendar.class)
+                ))
+        );
+
+        return dataset;
+    }
+
+    public static class MockRuntimeInvoker implements NetSuiteComponentDefinition.RuntimeInvoker {
+        protected NetSuiteRuntime runtime;
+
+        public MockRuntimeInvoker(NetSuiteRuntime runtime) {
+            this.runtime = runtime;
+        }
+
+        @Override
+        public <R> R invokeRuntime(NetSuiteRuntime.Context context, NetSuiteConnectionProperties properties,
+                Function<NetSuiteRuntime, R> func) {
+            runtime.setContext(context);
+            return func.apply(runtime);
+        }
+    }
+
+    public static class DatasetMockTestFixture {
+        protected TestDataset testDataset;
+        protected NetSuiteRuntime runtime;
+        protected NetSuiteDatasetRuntime datasetRuntime;
+
+        public DatasetMockTestFixture(TestDataset testDataset) {
+            this.testDataset = testDataset;
+        }
+
+        public void setUp() throws Exception {
+            runtime = mock(NetSuiteRuntime.class);
+            datasetRuntime = mock(NetSuiteDatasetRuntime.class);
+
+            installMockRuntime(runtime);
+
+            // Types
+
+            doReturn(new ArrayList<>(testDataset.getRecordTypes()))
+                    .when(datasetRuntime).getRecordTypes();
+
+            when(datasetRuntime.getSchema(anyString())).then(new Answer<Schema>() {
+                @Override public Schema answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    String typeName = (String) invocationOnMock.getArguments()[0];
+                    return testDataset.getTypeSchemaMap().get(typeName);
+                }
+            });
+
+            when(datasetRuntime.getSchemaForUpdate(anyString())).then(new Answer<Schema>() {
+                @Override public Schema answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    String typeName = (String) invocationOnMock.getArguments()[0];
+                    return testDataset.getTypeSchemaMap().get(typeName);
+                }
+            });
+
+            when(datasetRuntime.getSchemaForDelete(anyString())).then(new Answer<Schema>() {
+                @Override public Schema answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    return testDataset.getTypeSchemaMap().get("RecordRef");
+                }
+            });
+
+            // Search
+
+            doReturn(new ArrayList<>(testDataset.getSearchableTypes()))
+                    .when(datasetRuntime).getSearchableTypes();
+            doReturn(new ArrayList<>(testDataset.getSearchOperators()))
+                    .when(datasetRuntime).getSearchFieldOperators();
+
+            when(datasetRuntime.getSearchInfo(anyString())).then(new Answer<SearchInfo>() {
+                @Override public SearchInfo answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    String typeName = (String) invocationOnMock.getArguments()[0];
+                    return testDataset.getSearchInfoMap().get(typeName);
+                }
+            });
+        }
+
+        public void tearDown() throws Exception {
+
+        }
+
+        public TestDataset getTestDataset() {
+            return testDataset;
+        }
+
+        public NetSuiteRuntime getRuntime() {
+            return runtime;
+        }
+
+        public NetSuiteDatasetRuntime getDatasetRuntime() {
+            return datasetRuntime;
+        }
+    }
+
+    public static class TestDataset {
+        protected Collection<NamedThing> recordTypes = new HashSet<>();
+        protected Collection<NamedThing> searchableTypes = new HashSet<>();
+        protected Map<String, Schema> typeSchemaMap = new HashMap<>();
+        protected Collection<NamedThing> searchOperators = new HashSet<>();
+        protected Map<String, SearchInfo> searchInfoMap = new HashMap<>();
+
+        public Collection<NamedThing> getRecordTypes() {
+            return recordTypes;
+        }
+
+        public void setRecordTypes(Collection<NamedThing> recordTypes) {
+            this.recordTypes = recordTypes;
+        }
+
+        public Collection<NamedThing> getSearchableTypes() {
+            return searchableTypes;
+        }
+
+        public void setSearchableTypes(Collection<NamedThing> searchableTypes) {
+            this.searchableTypes = searchableTypes;
+        }
+
+        public Map<String, Schema> getTypeSchemaMap() {
+            return typeSchemaMap;
+        }
+
+        public void setTypeSchemaMap(Map<String, Schema> typeSchemaMap) {
+            this.typeSchemaMap = typeSchemaMap;
+        }
+
+        public Collection<NamedThing> getSearchOperators() {
+            return searchOperators;
+        }
+
+        public void setSearchOperators(Collection<NamedThing> searchOperators) {
+            this.searchOperators = searchOperators;
+        }
+
+        public Map<String, SearchInfo> getSearchInfoMap() {
+            return searchInfoMap;
+        }
+
+        public void setSearchInfoMap(Map<String, SearchInfo> searchInfoMap) {
+            this.searchInfoMap = searchInfoMap;
+        }
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/OsgiNetSuiteComponentTestIT.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/OsgiNetSuiteComponentTestIT.java
@@ -15,11 +15,6 @@ package org.talend.components.netsuite;
 
 import static org.ops4j.pax.exam.CoreOptions.*;
 
-import javax.inject.Inject;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
@@ -27,12 +22,10 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.talend.components.api.ComponentsPaxExamOptions;
-import org.talend.components.api.service.ComponentService;
-import org.talend.components.api.test.ComponentTestUtils;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-public class OsgiNetSuiteInputTestIT extends NetSuiteInputTestBase {
+public class OsgiNetSuiteComponentTestIT extends NetSuiteComponentTestBase {
 
     @Configuration
     public Option[] config() {

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
@@ -21,6 +21,6 @@ import org.talend.components.service.spring.SpringTestApp;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringTestApp.class)
 @Ignore
-public class SpringNetSuiteInputTestIT extends NetSuiteInputTestBase {
+public class SpringNetSuiteComponentTestIT extends NetSuiteComponentTestBase {
 
 }

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
@@ -12,7 +12,6 @@
 // ============================================================================
 package org.talend.components.netsuite;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -20,7 +19,6 @@ import org.talend.components.service.spring.SpringTestApp;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringTestApp.class)
-@Ignore
 public class SpringNetSuiteComponentTestIT extends NetSuiteComponentTestBase {
 
 }

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinitionTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinitionTest.java
@@ -1,0 +1,62 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.connection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.talend.components.api.component.ComponentDefinition.RETURN_ERROR_MESSAGE_PROP;
+
+import org.junit.Test;
+import org.talend.components.api.component.ConnectorTopology;
+import org.talend.components.api.component.runtime.ExecutionEngine;
+import org.talend.components.api.component.runtime.JarRuntimeInfo;
+import org.talend.daikon.properties.property.Property;
+import org.talend.daikon.runtime.RuntimeInfo;
+
+/**
+ *
+ */
+public class NetSuiteConnectionDefinitionTest {
+
+    private NetSuiteConnectionDefinition definition = new NetSuiteConnectionDefinition();
+
+    @Test
+    public void testBasic() {
+        assertEquals("tNetsuiteConnection", definition.getName());
+
+        assertThat(definition.getPropertyClass(), is(equalTo((Class) NetSuiteConnectionProperties.class)));
+
+        assertThat(definition.getReturnProperties().length, is(1));
+        assertThat(definition.getReturnProperties(), arrayContainingInAnyOrder((Property) RETURN_ERROR_MESSAGE_PROP));
+
+        assertThat(definition.getSupportedConnectorTopologies().size(), is(1));
+        assertThat(definition.getSupportedConnectorTopologies(), contains(ConnectorTopology.NONE));
+    }
+
+    @Test
+    public void testRuntimeInfo() {
+        NetSuiteConnectionProperties properties = new NetSuiteConnectionProperties("test");
+        properties.initForRuntime();
+
+        RuntimeInfo runtimeInfo = definition.getRuntimeInfo(ExecutionEngine.DI, properties, ConnectorTopology.NONE);
+        assertNotNull(runtimeInfo);
+        assertThat(runtimeInfo, instanceOf(JarRuntimeInfo.class));
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionPropertiesTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionPropertiesTest.java
@@ -1,0 +1,49 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.connection;
+
+import org.junit.Test;
+import org.talend.daikon.properties.presentation.Form;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ *
+ */
+public class NetSuiteConnectionPropertiesTest {
+
+    @Test
+    public void testSetup() {
+        NetSuiteConnectionProperties properties = new NetSuiteConnectionProperties("test");
+        properties.init();
+
+        assertNotNull(properties.endpoint.getValue());
+        assertNotNull(properties.email.getValue());
+        assertNotNull(properties.role.getValue());
+        assertNotNull(properties.account.getValue());
+        assertNotNull(properties.applicationId.getValue());
+    }
+
+    @Test
+    public void testSetupLayout() {
+        NetSuiteConnectionProperties properties = new NetSuiteConnectionProperties("test");
+        properties.init();
+
+        Form mainForm = properties.getForm(Form.MAIN);
+        assertNotNull(mainForm);
+
+        Form refForm = properties.getForm(Form.REFERENCE);
+        assertNotNull(refForm);
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputDefinitionTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputDefinitionTest.java
@@ -1,0 +1,64 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.input;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.talend.components.api.component.ComponentDefinition.RETURN_ERROR_MESSAGE_PROP;
+import static org.talend.components.api.component.ComponentDefinition.RETURN_TOTAL_RECORD_COUNT_PROP;
+
+import org.junit.Test;
+import org.talend.components.api.component.ConnectorTopology;
+import org.talend.components.api.component.runtime.ExecutionEngine;
+import org.talend.components.api.component.runtime.JarRuntimeInfo;
+import org.talend.daikon.properties.property.Property;
+import org.talend.daikon.runtime.RuntimeInfo;
+
+/**
+ *
+ */
+public class NetSuiteInputDefinitionTest {
+
+    private NetSuiteInputDefinition definition = new NetSuiteInputDefinition();
+
+    @Test
+    public void testBasic() {
+        assertEquals("tNetsuiteInput", definition.getName());
+
+        assertThat(definition.getPropertyClass(), is(equalTo((Class) NetSuiteInputProperties.class)));
+
+        assertThat(definition.getReturnProperties().length, is(2));
+        assertThat(definition.getReturnProperties(), arrayContainingInAnyOrder(
+                (Property) RETURN_ERROR_MESSAGE_PROP, (Property) RETURN_TOTAL_RECORD_COUNT_PROP));
+
+        assertThat(definition.getSupportedConnectorTopologies().size(), is(1));
+        assertThat(definition.getSupportedConnectorTopologies(), contains(ConnectorTopology.OUTGOING));
+    }
+
+    @Test
+    public void testRuntimeInfo() {
+        NetSuiteInputProperties properties = new NetSuiteInputProperties("test");
+        properties.initForRuntime();
+
+        RuntimeInfo runtimeInfo = definition.getRuntimeInfo(ExecutionEngine.DI, properties, ConnectorTopology.OUTGOING);
+        assertNotNull(runtimeInfo);
+        assertThat(runtimeInfo, instanceOf(JarRuntimeInfo.class));
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputPropertiesTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputPropertiesTest.java
@@ -1,0 +1,121 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.input;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.talend.components.netsuite.NetSuiteDatasetRuntime;
+import org.talend.components.netsuite.NetSuitePropertiesTestBase;
+import org.talend.components.netsuite.NetSuiteRuntime;
+import org.talend.daikon.properties.ValidationResult;
+import org.talend.daikon.properties.presentation.Form;
+
+/**
+ *
+ */
+public class NetSuiteInputPropertiesTest extends NetSuitePropertiesTestBase {
+    private DatasetMockTestFixture datasetMockTestFixture;
+    private TestDataset dataset;
+    private NetSuiteRuntime runtime;
+    private NetSuiteDatasetRuntime datasetRuntime;
+
+    private NetSuiteInputProperties properties;
+
+    @Before
+    public void setUp() throws Exception {
+        datasetMockTestFixture = new DatasetMockTestFixture(createTestDataset1());
+        datasetMockTestFixture.setUp();
+        dataset = datasetMockTestFixture.getTestDataset();
+        runtime = datasetMockTestFixture.getRuntime();
+        datasetRuntime = datasetMockTestFixture.getDatasetRuntime();
+
+        properties = new NetSuiteInputProperties("test");
+
+        when(runtime.getDatasetRuntime(eq(properties.connection))).thenReturn(datasetRuntime);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        datasetMockTestFixture.tearDown();
+    }
+
+    @Test
+    public void testSetup() {
+        properties.init();
+
+        assertNotNull(properties.getConnectionProperties());
+        assertEquals(1, properties.getAllSchemaPropertiesConnectors(true).size());
+        assertEquals(0, properties.getAllSchemaPropertiesConnectors(false).size());
+    }
+
+    @Test
+    public void testSetupLayout() {
+        properties.init();
+
+        Form mainForm = properties.getForm(Form.MAIN);
+        assertNotNull(mainForm);
+    }
+
+    @Test
+    public void testRefreshLayout() {
+        properties.init();
+
+        properties.refreshLayout(properties.getForm(Form.MAIN));
+    }
+
+    @Test
+    public void testSelectSearchTarget() throws Exception {
+        properties.init();
+
+        // Before module select
+
+        ValidationResult validationResult1 = properties.module.beforeModuleName();
+
+        verify(datasetRuntime, times(1)).getSearchableTypes();
+
+        assertNotNull(validationResult1);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult1.getStatus());
+
+        assertEquals(dataset.getSearchableTypes().size(),
+                properties.module.moduleName.getPossibleValues().size());
+
+        // Select module
+
+        properties.module.moduleName.setValue("Account");
+
+        // After module select
+
+        ValidationResult validationResult2 = properties.module.afterModuleName();
+
+        verify(datasetRuntime, times(1)).getSearchFieldOperators();
+        verify(datasetRuntime, times(1)).getSearchInfo(eq("Account"));
+        verify(datasetRuntime, times(1)).getSchema(eq("Account"));
+
+        assertNotNull(validationResult2);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult2.getStatus());
+
+        assertEquals(dataset.getSearchInfoMap().get("Account").getFields().size(),
+                properties.module.searchQuery.field.getPossibleValues().size());
+        assertEquals(dataset.getSearchOperators().size(),
+                properties.module.searchQuery.operator.getPossibleValues().size());
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputDefinitionTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputDefinitionTest.java
@@ -1,0 +1,64 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.output;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.talend.components.api.component.ComponentDefinition.RETURN_ERROR_MESSAGE_PROP;
+import static org.talend.components.api.component.ComponentDefinition.RETURN_TOTAL_RECORD_COUNT_PROP;
+
+import org.junit.Test;
+import org.talend.components.api.component.ConnectorTopology;
+import org.talend.components.api.component.runtime.ExecutionEngine;
+import org.talend.components.api.component.runtime.JarRuntimeInfo;
+import org.talend.daikon.properties.property.Property;
+import org.talend.daikon.runtime.RuntimeInfo;
+
+/**
+ *
+ */
+public class NetSuiteOutputDefinitionTest {
+
+    private NetSuiteOutputDefinition definition = new NetSuiteOutputDefinition();
+
+    @Test
+    public void testBasic() {
+        assertEquals("tNetsuiteOutput", definition.getName());
+
+        assertThat(definition.getPropertyClass(), is(equalTo((Class) NetSuiteOutputProperties.class)));
+
+        assertThat(definition.getReturnProperties().length, is(2));
+        assertThat(definition.getReturnProperties(), arrayContainingInAnyOrder(
+                (Property) RETURN_ERROR_MESSAGE_PROP, (Property) RETURN_TOTAL_RECORD_COUNT_PROP));
+
+        assertThat(definition.getSupportedConnectorTopologies().size(), is(1));
+        assertThat(definition.getSupportedConnectorTopologies(), contains(ConnectorTopology.INCOMING));
+    }
+
+    @Test
+    public void testRuntimeInfo() {
+        NetSuiteOutputProperties properties = new NetSuiteOutputProperties("test");
+        properties.initForRuntime();
+
+        RuntimeInfo runtimeInfo = definition.getRuntimeInfo(ExecutionEngine.DI, properties, ConnectorTopology.INCOMING);
+        assertNotNull(runtimeInfo);
+        assertThat(runtimeInfo, instanceOf(JarRuntimeInfo.class));
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputPropertiesTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputPropertiesTest.java
@@ -1,0 +1,172 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.output;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.talend.components.netsuite.NetSuiteDatasetRuntime;
+import org.talend.components.netsuite.NetSuitePropertiesTestBase;
+import org.talend.components.netsuite.NetSuiteRuntime;
+import org.talend.daikon.properties.ValidationResult;
+import org.talend.daikon.properties.presentation.Form;
+
+/**
+ *
+ */
+public class NetSuiteOutputPropertiesTest extends NetSuitePropertiesTestBase {
+    private DatasetMockTestFixture datasetMockTestFixture;
+    private TestDataset dataset;
+    private NetSuiteRuntime runtime;
+    private NetSuiteDatasetRuntime datasetRuntime;
+
+    private NetSuiteOutputProperties properties;
+
+    @Before
+    public void setUp() throws Exception {
+        datasetMockTestFixture = new DatasetMockTestFixture(createTestDataset1());
+        datasetMockTestFixture.setUp();
+        dataset = datasetMockTestFixture.getTestDataset();
+        runtime = datasetMockTestFixture.getRuntime();
+        datasetRuntime = datasetMockTestFixture.getDatasetRuntime();
+
+        properties = new NetSuiteOutputProperties("test");
+
+        when(runtime.getDatasetRuntime(eq(properties.connection))).thenReturn(datasetRuntime);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        datasetMockTestFixture.tearDown();
+    }
+
+    @Test
+    public void testSetup() {
+        properties.init();
+
+        assertEquals(OutputAction.ADD, properties.module.action.getValue());
+
+        assertNotNull(properties.getConnectionProperties());
+        assertEquals(1, properties.getAllSchemaPropertiesConnectors(false).size());
+        assertEquals(0, properties.getAllSchemaPropertiesConnectors(true).size());
+    }
+
+    @Test
+    public void testSetupLayout() {
+        properties.init();
+
+        Form mainForm = properties.getForm(Form.MAIN);
+        assertNotNull(mainForm);
+    }
+
+    @Test
+    public void testRefreshLayout() {
+        properties.init();
+
+        properties.refreshLayout(properties.getForm(Form.MAIN));
+    }
+
+    @Test
+    public void testSelectTargetForUpdate() throws Exception {
+        properties.init();
+
+        // Before module select
+
+        ValidationResult validationResult1 = properties.module.beforeModuleName();
+
+        verify(datasetRuntime, times(1)).getRecordTypes();
+
+        assertNotNull(validationResult1);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult1.getStatus());
+
+        assertEquals(dataset.getRecordTypes().size(),
+                properties.module.moduleName.getPossibleValues().size());
+
+        // Select module
+
+        properties.module.moduleName.setValue("Account");
+
+        // After module select
+
+        ValidationResult validationResult2 = properties.module.afterModuleName();
+
+        verify(datasetRuntime, times(1)).getSchemaForUpdate(eq("Account"));
+
+        assertNotNull(validationResult2);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult2.getStatus());
+
+        // Select action
+
+        properties.module.action.setValue(OutputAction.UPDATE);
+
+        // After action select
+
+        ValidationResult validationResult3 = properties.module.afterAction();
+
+        verify(datasetRuntime, times(2)).getSchemaForUpdate(eq("Account"));
+
+        assertNotNull(validationResult3);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult3.getStatus());
+    }
+
+    @Test
+    public void testSelectTargetForDelete() throws Exception {
+        properties.init();
+
+        // Before module select
+
+        ValidationResult validationResult1 = properties.module.beforeModuleName();
+
+        verify(datasetRuntime, times(1)).getRecordTypes();
+
+        assertNotNull(validationResult1);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult1.getStatus());
+
+        assertEquals(dataset.getRecordTypes().size(),
+                properties.module.moduleName.getPossibleValues().size());
+
+        // Select module
+
+        properties.module.moduleName.setValue("Account");
+
+        // After module select
+
+        ValidationResult validationResult2 = properties.module.afterModuleName();
+
+        verify(datasetRuntime, times(1)).getSchemaForUpdate(eq("Account"));
+
+        assertNotNull(validationResult2);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult2.getStatus());
+
+        // Select action
+
+        properties.module.action.setValue(OutputAction.DELETE);
+
+        // After action select
+
+        ValidationResult validationResult3 = properties.module.afterAction();
+
+        verify(datasetRuntime, times(1)).getSchemaForDelete(eq("Account"));
+
+        assertNotNull(validationResult3);
+        assertEquals(ValidationResult.OK.getStatus(), validationResult3.getStatus());
+    }
+}

--- a/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/util/ComponentExceptionsTest.java
+++ b/components/components-netsuite/netsuite-definition/src/test/java/org/talend/components/netsuite/util/ComponentExceptionsTest.java
@@ -1,0 +1,52 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.xml.ws.WebServiceException;
+
+import org.junit.Test;
+import org.talend.components.api.exception.ComponentException;
+import org.talend.daikon.exception.error.CommonErrorCodes;
+import org.talend.daikon.properties.ValidationResult;
+
+/**
+ *
+ */
+public class ComponentExceptionsTest {
+
+    @Test
+    public void testExceptionToValidationResult() {
+        ValidationResult result1 = ComponentExceptions.exceptionToValidationResult(
+                new WebServiceException("TEST"));
+        assertNotNull(result1);
+        assertEquals(ValidationResult.Result.ERROR, result1.getStatus());
+        assertEquals("TEST", result1.getMessage());
+
+        ValidationResult result2 = ComponentExceptions.exceptionToValidationResult(
+                new ComponentException(CommonErrorCodes.UNEXPECTED_EXCEPTION,
+                        new WebServiceException("TEST")));
+        assertNotNull(result2);
+        assertEquals(ValidationResult.Result.ERROR, result2.getStatus());
+        assertEquals(CommonErrorCodes.UNEXPECTED_EXCEPTION.name(), result2.getMessage());
+
+        ValidationResult controlResult = new ValidationResult()
+                .setStatus(ValidationResult.Result.ERROR).setMessage("TEST");
+        ValidationResult result3 = ComponentExceptions.exceptionToValidationResult(
+                new ComponentException(controlResult));
+        assertEquals(controlResult, result3);
+    }
+}

--- a/components/components-netsuite/netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSourceOrSink.java
+++ b/components/components-netsuite/netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSourceOrSink.java
@@ -40,6 +40,7 @@ public abstract class NetSuiteSourceOrSink implements SourceOrSink {
     protected transient final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected NetSuiteClientFactory<?> clientFactory;
+
     protected NetSuiteProvideConnectionProperties properties;
 
     protected transient NetSuiteEndpoint endpoint;
@@ -92,8 +93,8 @@ public abstract class NetSuiteSourceOrSink implements SourceOrSink {
     }
 
     public NetSuiteConnectionProperties getConnectionProperties() {
-    return properties.getConnectionProperties();
-}
+        return properties.getConnectionProperties();
+    }
 
     public NetSuiteProvideConnectionProperties getProperties() {
         return properties;

--- a/components/components-netsuite/netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorTypeDesc.java
+++ b/components/components-netsuite/netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorTypeDesc.java
@@ -87,7 +87,7 @@ public class SearchFieldOperatorTypeDesc<T> {
         } else {
             if (!opName.getDataType().equals(operatorType.getDataType())) {
                 throw new IllegalArgumentException(
-                        "Invalid operator data type: " + "'" + opName.getDataType() + "' != '" + opName.getDataType() + "'");
+                        "Invalid operator data type: " + "'" + opName.getDataType() + "' != '" + operatorType.getDataType() + "'");
             }
             return mapFromString(opName.getName());
         }

--- a/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteTestBase.java
+++ b/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteTestBase.java
@@ -42,8 +42,8 @@ public abstract class AbstractNetSuiteTestBase {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    protected static List<TestFixture> classScopedTestFixtures = new ArrayList<>();
-    protected List<TestFixture> testFixtures = new ArrayList<>();
+    protected static TestFixtures classScopedTestFixtures = new TestFixtures();
+    protected TestFixtures testFixtures = new TestFixtures();
 
     protected static Random rnd = new Random(System.currentTimeMillis());
     protected static DatatypeFactory datatypeFactory;
@@ -57,33 +57,19 @@ public abstract class AbstractNetSuiteTestBase {
     }
 
     public void setUp() throws Exception {
-        for (TestFixture testFixture : testFixtures) {
-            testFixture.setUp();
-        }
+        testFixtures.setUp();
     }
 
     public void tearDown() throws Exception {
-        List<TestFixture> reversed = new ArrayList<>(testFixtures);
-        Collections.reverse(reversed);
-        for (TestFixture testFixture : reversed) {
-            testFixture.tearDown();
-        }
-        testFixtures.clear();
+        testFixtures.tearDown();
     }
 
     public static void setUpClassScopedTestFixtures() throws Exception {
-        for (TestFixture testFixture : classScopedTestFixtures) {
-            testFixture.setUp();
-        }
+        classScopedTestFixtures.setUp();
     }
 
     public static void tearDownClassScopedTestFixtures() throws Exception {
-        List<TestFixture> reversed = new ArrayList<>(classScopedTestFixtures);
-        Collections.reverse(reversed);
-        for (TestFixture testFixture : reversed) {
-            testFixture.tearDown();
-        }
-        classScopedTestFixtures.clear();
+        classScopedTestFixtures.tearDown();
     }
 
     protected Schema getDynamicSchema() {
@@ -208,4 +194,40 @@ public abstract class AbstractNetSuiteTestBase {
             return nsObject;
         }
     }
+
+    public static class TestFixtures implements TestFixture {
+        protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+        protected List<TestFixture> testFixtures = new ArrayList<>();
+
+        public void add(TestFixture testFixture) {
+            testFixtures.add(testFixture);
+        }
+
+        public void clear() {
+            testFixtures.clear();
+        }
+
+        @Override
+        public void setUp() throws Exception {
+            for (TestFixture testFixture : testFixtures) {
+                testFixture.setUp();
+            }
+        }
+
+        @Override
+        public void tearDown() throws Exception {
+            List<TestFixture> reversed = new ArrayList<>(testFixtures);
+            Collections.reverse(reversed);
+            for (TestFixture testFixture : reversed) {
+                try {
+                    testFixture.tearDown();
+                } catch (Exception | Error e) {
+                    logger.error("Failed to tearDown test fixture: {}", testFixture, e);
+                }
+            }
+            clear();
+        }
+    }
+
 }

--- a/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceMockTestFixture.java
+++ b/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceMockTestFixture.java
@@ -31,6 +31,8 @@ import javax.xml.ws.Endpoint;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.cxf.headers.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.talend.components.netsuite.client.NetSuiteClientFactory;
 import org.talend.components.netsuite.client.NetSuiteClientService;
 import org.talend.components.netsuite.client.NetSuiteCredentials;
@@ -38,6 +40,7 @@ import org.talend.components.netsuite.client.model.CustomFieldDesc;
 import org.talend.components.netsuite.client.model.FieldDesc;
 import org.talend.components.netsuite.client.model.TypeDesc;
 import org.talend.components.netsuite.client.model.beans.Beans;
+import org.talend.components.netsuite.test.FreePortFinder;
 import org.talend.components.netsuite.test.TestFixture;
 import org.talend.components.netsuite.util.Mapper;
 
@@ -46,6 +49,8 @@ import org.talend.components.netsuite.util.Mapper;
  */
 public class NetSuiteWebServiceMockTestFixture<PortT, AdapterT extends NetSuitePortTypeMockAdapter<PortT>>
         implements TestFixture {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private NetSuiteClientFactory<PortT> clientFactory;
     private NetSuiteServiceFactory<?> serviceFactory;
@@ -78,7 +83,10 @@ public class NetSuiteWebServiceMockTestFixture<PortT, AdapterT extends NetSuiteP
     public void setUp() throws Exception {
         System.setProperty("com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize", "true");
 
-        URL endpointAddress = new URL("http://localhost:8088/services/" + portName);
+        int portNumber = FreePortFinder.findFreePort(8080, FreePortFinder.MAX_PORT_NUMBER);
+        URL endpointAddress = new URL("http://localhost:" + portNumber + "/services/" + portName);
+
+        logger.info("Endpoint address: {}", endpointAddress);
 
         portMockAdapter = portAdapterClass.newInstance();
         portMockAdapter.setEndpointAddress(endpointAddress);
@@ -89,6 +97,8 @@ public class NetSuiteWebServiceMockTestFixture<PortT, AdapterT extends NetSuiteP
         assertEquals("http://schemas.xmlsoap.org/wsdl/soap/http", endpoint.getBinding().getBindingID());
 
         URL wsdlLocation = new URL(endpointAddress.toString().concat("?wsdl"));
+//        assertNotNull(wsdlLocation.getContent());
+
         service = serviceFactory.createService(wsdlLocation);
 
         credentials = new NetSuiteCredentials(

--- a/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/test/FreePortFinder.java
+++ b/components/components-netsuite/netsuite-runtime/src/test/java/org/talend/components/netsuite/test/FreePortFinder.java
@@ -1,0 +1,89 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.netsuite.test;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+
+/**
+ * Finds an available port on localhost.
+ */
+public class FreePortFinder {
+
+    // the ports below 1024 are system ports
+    public static final int MIN_PORT_NUMBER = 1024;
+
+    // the ports above 49151 are dynamic and/or private
+    public static final int MAX_PORT_NUMBER = 49151;
+
+    /**
+     * Finds a free port between
+     * {@link #MIN_PORT_NUMBER} and {@link #MAX_PORT_NUMBER}.
+     *
+     * @return a free port
+     * @throw RuntimeException if a port could not be found
+     */
+    public static int findFreePort() {
+        return findFreePort(MIN_PORT_NUMBER, MAX_PORT_NUMBER);
+    }
+
+    /**
+     * Finds a free port between
+     * <code>minPortNumber</code> and <code>maxPortNumber</code>.
+     *
+     * @return a free port
+     * @throw RuntimeException if a port could not be found
+     */
+    public static int findFreePort(int minPortNumber, int maxPortNumber) {
+        for (int i = minPortNumber; i <= maxPortNumber; i++) {
+            if (available(i)) {
+                return i;
+            }
+        }
+        throw new RuntimeException("Could not find an available port between " +
+                minPortNumber + " and " + maxPortNumber);
+    }
+
+    /**
+     * Returns true if the specified port is available on this host.
+     *
+     * @param port the port to check
+     * @return true if the port is available, false otherwise
+     */
+    private static boolean available(final int port) {
+        ServerSocket serverSocket = null;
+        DatagramSocket dataSocket = null;
+        try {
+            serverSocket = new ServerSocket(port);
+            serverSocket.setReuseAddress(true);
+            dataSocket = new DatagramSocket(port);
+            dataSocket.setReuseAddress(true);
+            return true;
+        } catch (final IOException e) {
+            return false;
+        } finally {
+            if (dataSocket != null) {
+                dataSocket.close();
+            }
+            if (serverSocket != null) {
+                try {
+                    serverSocket.close();
+                } catch (final IOException e) {
+                    // can never happen
+                }
+            }
+        }
+    }
+}

--- a/components/components-netsuite/netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/netsuite-runtime_2014_2/pom.xml
@@ -129,6 +129,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>com/netsuite/webservices/**/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
             <!-- Add Apache CXF generated sources to sources set. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/components/components-netsuite/netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/netsuite-runtime_2016_2/pom.xml
@@ -129,6 +129,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>com/netsuite/webservices/**/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
             <!-- Add Apache CXF generated sources to sources set. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
- Tests for definitions and properties are absent
- Classes generated from WSDL are included into coverage report and this decreases coverage percentage
- After record type was selected it is not possible to add search condition due to an exception (https://jira.talendforge.org/browse/TDI-38452)
- For some SOAP requests timeout exception can be raised because default timeout is not sufficient

**What is the new behavior?**
- Tests for definitions and properties are present and passed
- Classes generated from WSDL are excluded from coverage report and now coverate report reflects adequate coverage percentage
- After record type was selected it is possible to add search condition
- Default timeout (for connecting and receiving) increased and long running SOAP requests do not cause timeout exception

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No