### PR TITLE
fix(TDI-38356): keep the order of the dynamic schema as is in azure

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableProperties.java
@@ -71,11 +71,11 @@ public class TAzureStorageInputTableProperties extends AzureStorageTableProperti
         // default Input schema
         Schema s = SchemaBuilder.record("Main").fields()
                 //
-                .name("RowKey").prop(SchemaConstants.TALEND_COLUMN_IS_KEY, "true")
-                .prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
+                .name("PartitionKey").prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
                 .prop(SchemaConstants.TALEND_IS_LOCKED, "true").type(AvroUtils._string()).noDefault()
                 //
-                .name("PartitionKey").prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
+                .name("RowKey").prop(SchemaConstants.TALEND_COLUMN_IS_KEY, "true")
+                .prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
                 .prop(SchemaConstants.TALEND_IS_LOCKED, "true").type(AvroUtils._string()).noDefault()
                 //
                 .name("Timestamp").prop(SchemaConstants.TALEND_COLUMN_PATTERN, "yyyy-MM-dd hh:mm:ss")// $NON-NLS-3$

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableBaseTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableBaseTestIT.java
@@ -111,11 +111,11 @@ public abstract class AzureStorageTableBaseTestIT extends AzureStorageBaseTestIT
     public Schema getSystemSchema() {
         return SchemaBuilder.record("Main").fields()
                 //
-                .name("RowKey").prop(SchemaConstants.TALEND_COLUMN_IS_KEY, "true")
-                .prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
+                .name("PartitionKey").prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
                 .prop(SchemaConstants.TALEND_IS_LOCKED, "true").type(AvroUtils._string()).noDefault()
                 //
-                .name("PartitionKey").prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
+                .name("RowKey").prop(SchemaConstants.TALEND_COLUMN_IS_KEY, "true")
+                .prop(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255")// $NON-NLS-3$
                 .prop(SchemaConstants.TALEND_IS_LOCKED, "true").type(AvroUtils._string()).noDefault()
                 //
                 .name("Timestamp").prop(SchemaConstants.TALEND_COLUMN_PATTERN, "yyyy-MM-dd hh:mm:ss")// $NON-NLS-3$

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/TAzureStorageInputTableTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/TAzureStorageInputTableTestIT.java
@@ -15,7 +15,11 @@ package org.talend.components.azurestorage.table.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.*;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_EQUAL;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_GREATER_THAN;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_DATE;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_STRING;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.PREDICATE_AND;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -134,7 +138,7 @@ public class TAzureStorageInputTableTestIT extends AzureStorageTableBaseTestIT {
         reader.close();
     }
 
-    @SuppressWarnings({"rawtypes"})
+    @SuppressWarnings({ "rawtypes" })
     @Test
     public void testFilterReader() throws Throwable {
         Date startTest = new Date();
@@ -144,7 +148,6 @@ public class TAzureStorageInputTableTestIT extends AzureStorageTableBaseTestIT {
         createSampleDataset(ctable);
 
         properties.tableName.setValue(ctable);
-        // String f = String.format("datetime\'%s:00Z\'", sdf);
         properties.useFilterExpression.setValue(true);
         List<String> cols = Arrays.asList("PartitionKey", "Timestamp");
         List<String> ops = Arrays.asList(pk_test1, sdf);
@@ -156,7 +159,7 @@ public class TAzureStorageInputTableTestIT extends AzureStorageTableBaseTestIT {
         properties.filterExpression.operand.setValue(ops);
         properties.filterExpression.predicate.setValue(preds);
         properties.filterExpression.fieldType.setValue(types);
-        // properties.combinedFilter.setValue(f);
+
         properties.schema.schema.setValue(getDynamicSchema());
         BoundedReader reader = createBoundedReader(properties);
         assertTrue(reader.start());
@@ -184,6 +187,7 @@ public class TAzureStorageInputTableTestIT extends AzureStorageTableBaseTestIT {
         while (reader.advance()) {
             IndexedRecord current = (IndexedRecord) reader.getCurrent();
             assertNotNull(current);
+            assertEquals(getSystemSchema(), current.getSchema());
             assertEquals(3, current.getSchema().getFields().size());
         }
         reader.close();


### PR DESCRIPTION
table

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38356

**What is the new behavior?**
we keep the order as is in the azure table


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No