### PR TITLE
fix(TDI-38338): add boolean type to filter expressions table

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTable.java
@@ -68,13 +68,15 @@ public class FilterExpressionTable extends ComponentPropertiesImpl {
 
     public static final String FIELD_TYPE_GUID = "GUID";
 
-    public static final String[] COMPARISONS = {COMPARISON_EQUAL, COMPARISON_NOT_EQUAL, COMPARISON_GREATER_THAN,
-            COMPARISON_GREATER_THAN_OR_EQUAL, COMPARISON_LESS_THAN, COMPARISON_LESS_THAN_OR_EQUAL};
+    public static final String FIELD_TYPE_BOOLEAN = "BOOLEAN";
 
-    public static final String[] PREDICATES = {PREDICATE_AND, PREDICATE_OR, PREDICATE_NOT};
+    public static final String[] COMPARISONS = { COMPARISON_EQUAL, COMPARISON_NOT_EQUAL, COMPARISON_GREATER_THAN,
+            COMPARISON_GREATER_THAN_OR_EQUAL, COMPARISON_LESS_THAN, COMPARISON_LESS_THAN_OR_EQUAL };
 
-    public static final String[] FIELD_TYPES = {FIELD_TYPE_STRING, FIELD_TYPE_NUMERIC, FIELD_TYPE_DATE, FIELD_TYPE_INT64,
-            FIELD_TYPE_BINARY, FIELD_TYPE_GUID};
+    public static final String[] PREDICATES = { PREDICATE_AND, PREDICATE_OR, PREDICATE_NOT };
+
+    public static final String[] FIELD_TYPES = { FIELD_TYPE_STRING, FIELD_TYPE_NUMERIC, FIELD_TYPE_DATE, FIELD_TYPE_INT64,
+            FIELD_TYPE_BOOLEAN, FIELD_TYPE_BINARY, FIELD_TYPE_GUID };
 
     public static final TypeLiteral<List<String>> LIST_STRING_TYPE = new TypeLiteral<List<String>>() {
     };
@@ -88,7 +90,7 @@ public class FilterExpressionTable extends ComponentPropertiesImpl {
     public Property<List<String>> predicate = newProperty(LIST_STRING_TYPE, "predicate");
 
     public Property<List<String>> fieldType = newProperty(LIST_STRING_TYPE, "fieldType");
-    
+
     private static final I18nMessages i18nMessages = GlobalI18N.getI18nMessageProvider()
             .getI18nMessages(FilterExpressionTable.class);
 
@@ -124,52 +126,54 @@ public class FilterExpressionTable extends ComponentPropertiesImpl {
 
     public String getComparison(String f) {
         switch (f) {
-            case COMPARISON_EQUAL :
-                return QueryComparisons.EQUAL;
-            case COMPARISON_NOT_EQUAL :
-                return QueryComparisons.NOT_EQUAL;
-            case COMPARISON_GREATER_THAN :
-                return QueryComparisons.GREATER_THAN;
-            case COMPARISON_GREATER_THAN_OR_EQUAL :
-                return QueryComparisons.GREATER_THAN_OR_EQUAL;
-            case COMPARISON_LESS_THAN :
-                return QueryComparisons.LESS_THAN;
-            case COMPARISON_LESS_THAN_OR_EQUAL :
-                return QueryComparisons.LESS_THAN_OR_EQUAL;
-            default :
-                return null;
+        case COMPARISON_EQUAL:
+            return QueryComparisons.EQUAL;
+        case COMPARISON_NOT_EQUAL:
+            return QueryComparisons.NOT_EQUAL;
+        case COMPARISON_GREATER_THAN:
+            return QueryComparisons.GREATER_THAN;
+        case COMPARISON_GREATER_THAN_OR_EQUAL:
+            return QueryComparisons.GREATER_THAN_OR_EQUAL;
+        case COMPARISON_LESS_THAN:
+            return QueryComparisons.LESS_THAN;
+        case COMPARISON_LESS_THAN_OR_EQUAL:
+            return QueryComparisons.LESS_THAN_OR_EQUAL;
+        default:
+            return null;
         }
     }
 
     public String getOperator(String p) {
         switch (p) {
-            case PREDICATE_AND :
-                return Operators.AND;
-            case PREDICATE_OR :
-                return Operators.OR;
-            case PREDICATE_NOT :
-                return Operators.NOT;
-            default :
-                return null;
+        case PREDICATE_AND:
+            return Operators.AND;
+        case PREDICATE_OR:
+            return Operators.OR;
+        case PREDICATE_NOT:
+            return Operators.NOT;
+        default:
+            return null;
         }
     }
 
     public EdmType getType(String ft) {
         switch (ft) {
-            case FIELD_TYPE_STRING :
-                return EdmType.STRING;
-            case FIELD_TYPE_NUMERIC :
-                return EdmType.INT32;
-            case FIELD_TYPE_INT64 :
-                return EdmType.INT64;
-            case FIELD_TYPE_DATE :
-                return EdmType.DATE_TIME;
-            case FIELD_TYPE_BINARY :
-                return EdmType.BINARY;
-            case FIELD_TYPE_GUID :
-                return EdmType.GUID;
-            default :
-                return null;
+        case FIELD_TYPE_STRING:
+            return EdmType.STRING;
+        case FIELD_TYPE_NUMERIC:
+            return EdmType.INT32;
+        case FIELD_TYPE_INT64:
+            return EdmType.INT64;
+        case FIELD_TYPE_DATE:
+            return EdmType.DATE_TIME;
+        case FIELD_TYPE_BINARY:
+            return EdmType.BINARY;
+        case FIELD_TYPE_GUID:
+            return EdmType.GUID;
+        case FIELD_TYPE_BOOLEAN:
+            return EdmType.BOOLEAN;
+        default:
+            return null;
         }
     }
 

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/AzureStorageTableComponentsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/AzureStorageTableComponentsTest.java
@@ -12,6 +12,7 @@
 // ============================================================================
 package org.talend.components.azurestorage.table;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -85,10 +86,10 @@ public class AzureStorageTableComponentsTest {
         assertNotNull(azureStorageTableDefinition.getRuntimeInfo(null, null, ConnectorTopology.INCOMING));
     }
 
-    @SuppressWarnings("deprecation")
+
     @Test
     public void testGetNestedCompatibleComponentPropertiesClass() {
-        assertEquals(new Class[] { TAzureStorageConnectionProperties.class, AzureStorageTableProperties.class },
+        assertArrayEquals(new Class[] { TAzureStorageConnectionProperties.class, AzureStorageTableProperties.class },
                 azureStorageTableDefinition.getNestedCompatibleComponentPropertiesClass());
     }
 

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
@@ -15,7 +15,22 @@ package org.talend.components.azurestorage.table.helpers;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.*;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_EQUAL;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_GREATER_THAN;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_GREATER_THAN_OR_EQUAL;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_LESS_THAN;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_LESS_THAN_OR_EQUAL;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.COMPARISON_NOT_EQUAL;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_BINARY;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_BOOLEAN;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_DATE;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_GUID;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_INT64;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_NUMERIC;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.FIELD_TYPE_STRING;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.PREDICATE_AND;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.PREDICATE_NOT;
+import static org.talend.components.azurestorage.table.helpers.FilterExpressionTable.PREDICATE_OR;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +87,9 @@ public class FilterExpressionTableTest {
                 fet.function.getValue().toString());
 
         assertEquals(Arrays.asList(COMPARISON_GREATER_THAN, COMPARISON_EQUAL, COMPARISON_LESS_THAN), fet.function.getValue());
+
+        assertEquals(Arrays.asList(FIELD_TYPE_STRING, FIELD_TYPE_NUMERIC, FIELD_TYPE_DATE, FIELD_TYPE_INT64, FIELD_TYPE_BOOLEAN,
+                FIELD_TYPE_BINARY, FIELD_TYPE_GUID), fet.fieldType.getPossibleValues());
     }
 
     @Test
@@ -116,6 +134,18 @@ public class FilterExpressionTableTest {
         query = fet.getCombinedFilterConditions();
         assertEquals(query,
                 "(((PartitionKey eq '12345') and (RowKey gt 'AVID12345')) or (Timestamp ge datetime'2016-01-01 00:00:00')) or (AnUnknownProperty lt 'WEB345')");
+
+        // Boolean
+        clearLists();
+        columns.add("ABooleanProperty");
+        functions.add(COMPARISON_EQUAL);
+        values.add("true");
+        predicates.add(PREDICATE_AND);
+        fieldTypes.add(FIELD_TYPE_STRING);
+        setTableVals();
+        query = fet.getCombinedFilterConditions();
+        assertEquals("ABooleanProperty eq 'true'", query);
+
     }
 
     @Test
@@ -154,6 +184,7 @@ public class FilterExpressionTableTest {
         assertEquals(EdmType.BINARY, fet.getType(FIELD_TYPE_BINARY));
         assertEquals(EdmType.GUID, fet.getType(FIELD_TYPE_GUID));
         assertEquals(EdmType.DATE_TIME, fet.getType(FIELD_TYPE_DATE));
+        assertEquals(EdmType.BOOLEAN, fet.getType(FIELD_TYPE_BOOLEAN));
     }
 
     @Test

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
@@ -136,15 +136,16 @@ public class FilterExpressionTableTest {
                 "(((PartitionKey eq '12345') and (RowKey gt 'AVID12345')) or (Timestamp ge datetime'2016-01-01 00:00:00')) or (AnUnknownProperty lt 'WEB345')");
 
         // Boolean
-        clearLists();
         columns.add("ABooleanProperty");
         functions.add(COMPARISON_EQUAL);
         values.add("true");
         predicates.add(PREDICATE_AND);
-        fieldTypes.add(FIELD_TYPE_STRING);
+        fieldTypes.add(FIELD_TYPE_BOOLEAN);
         setTableVals();
         query = fet.getCombinedFilterConditions();
-        assertEquals("ABooleanProperty eq 'true'", query);
+        assertEquals(
+                "((((PartitionKey eq '12345') and (RowKey gt 'AVID12345')) or (Timestamp ge datetime'2016-01-01 00:00:00')) or (AnUnknownProperty lt 'WEB345')) and (ABooleanProperty eq true)",
+                query);
 
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
please refer to : https://jira.talendforge.org/browse/TDI-38338

**What is the new behavior?**
the boolean type is available in the filter expression table and can be used to construct filters


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
