### PR TITLE
fix(TDI-38302): fix NPE in azure table writer when record value is null

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
@@ -66,7 +66,7 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
 
     private IndexedRecord inputRecord;
 
-    private IndexedRecordConverter<IndexedRecord, IndexedRecord> factory;
+    private IndexedRecordConverter<IndexedRecord, IndexedRecord> converter;
 
     private Result result;
 
@@ -103,7 +103,7 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
     private Boolean useNameMappings = Boolean.FALSE;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureStorageTableWriter.class);
-    
+
     private static final I18nMessages i18nMessages = GlobalI18N.getI18nMessageProvider()
             .getI18nMessages(AzureStorageTableWriter.class);
 
@@ -209,24 +209,27 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
         if (writeSchema == null) {
             writeSchema = ((IndexedRecord) object).getSchema();
         }
-        inputRecord = getFactory(object).convertToAvro((IndexedRecord) object);
+        inputRecord = getConverter(object).convertToAvro((IndexedRecord) object);
         DynamicTableEntity entity = new DynamicTableEntity();
         HashMap<String, EntityProperty> entityProps = new HashMap<>();
         for (Field f : writeSchema.getFields()) {
-            String sName = f.name(); // schema name
-            String mName = sName; // mapped name
-            if (useNameMappings) {
-                if (nameMappings.containsKey(sName)) {
-                    mName = nameMappings.get(sName);
-                }
+            if (inputRecord.get(f.pos()) == null) {
+                continue; // record value my be null, No need to set the property in azure in this case
             }
+
+            String sName = f.name(); // schema name
+            String mName = getMappedNameIfNecessary(sName); // mapped name
+
             Schema fSchema = f.schema();
-            if (fSchema.getType() == Type.UNION)
-                for (Schema s : f.schema().getTypes())
+            if (fSchema.getType() == Type.UNION) {
+                for (Schema s : f.schema().getTypes()) {
                     if (s.getType() != Type.NULL) {
                         fSchema = s;
                         break;
                     }
+                }
+            }
+
             if (sName.equals(AzureStorageTableProperties.TABLE_PARTITION_KEY)
                     || mName.equals(AzureStorageTableProperties.TABLE_PARTITION_KEY)) {
                 entity.setPartitionKey((String) inputRecord.get(f.pos()));
@@ -252,17 +255,18 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
                     if (clazz != null && clazz.equals(Date.class.getCanonicalName())) {
                         Date dt = null;
                         try {
-                            dt = new SimpleDateFormat(fSchema.getProp(SchemaConstants.TALEND_COLUMN_PATTERN))
-                                    .parse(inputRecord.get(f.pos()).toString());
+                            String pattern = fSchema.getProp(SchemaConstants.TALEND_COLUMN_PATTERN);
+                            dt = new SimpleDateFormat(pattern).parse(inputRecord.get(f.pos()).toString());
                             entityProps.put(mName, new EntityProperty(dt));
                         } catch (ParseException e) {
-                            LOGGER.error(i18nMessages.getMessage("error.ParseError",e));
+                            LOGGER.error(i18nMessages.getMessage("error.ParseError", e));
                             if (properties.dieOnError.getValue()) {
                                 throw new ComponentException(e);
                             }
                         }
-                    } else
+                    } else {
                         entityProps.put(mName, new EntityProperty((Long) inputRecord.get(f.pos())));
+                    }
                 }
                 //
                 else if (fSchema.getType().equals(Type.STRING)) {
@@ -284,10 +288,23 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
         }
     }
 
+    /**
+     * this method return the mapped name is useNameMappings is true else it return the original name
+     */
+    private String getMappedNameIfNecessary(String sName) {
+        if (useNameMappings) {
+            if (nameMappings.containsKey(sName)) {
+                return nameMappings.get(sName);
+            }
+        }
+
+        return sName;
+    }
+
     @Override
     public Result close() throws IOException {
         if (batchOperationsCount > 0) {
-            LOGGER.debug(i18nMessages.getMessage("debug.ExecutingBrtch",batchOperationsCount));
+            LOGGER.debug(i18nMessages.getMessage("debug.ExecutingBrtch", batchOperationsCount));
             processBatch();
         }
         table = null;
@@ -310,12 +327,12 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
         return Collections.unmodifiableList(rejectedWrites);
     }
 
-    private IndexedRecordConverter<IndexedRecord, IndexedRecord> getFactory(Object datum) {
-        if (factory == null) {
-            factory = new GenericIndexedRecordConverter();
-            factory.setSchema(writeSchema);
+    private IndexedRecordConverter<IndexedRecord, IndexedRecord> getConverter(Object datum) {
+        if (converter == null) {
+            converter = new GenericIndexedRecordConverter();
+            converter.setSchema(writeSchema);
         }
-        return factory;
+        return converter;
     }
 
     private TableOperation getTableOperation(DynamicTableEntity entity) {
@@ -352,7 +369,7 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
             table.execute(ope);
             handleSuccess(inputRecord, 1);
         } catch (StorageException e) {
-            LOGGER.error(i18nMessages.getMessage("error.ProcessSingleOperation",actionData,e.getLocalizedMessage()));
+            LOGGER.error(i18nMessages.getMessage("error.ProcessSingleOperation", actionData, e.getLocalizedMessage()));
 
             if (properties.dieOnError.getValue()) {
                 throw new ComponentException(e);
@@ -387,7 +404,7 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
             handleSuccess(null, batchOperationsCount);
 
         } catch (StorageException e) {
-            LOGGER.error(i18nMessages.getMessage("error.ProcessBatch",actionData,e.getLocalizedMessage()));
+            LOGGER.error(i18nMessages.getMessage("error.ProcessBatch", actionData, e.getLocalizedMessage()));
 
             handleReject(null, e, batchOperationsCount);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38302


**What is the new behavior?**
No need to set the azure table entity property when the record value is null.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
