### PR TITLE
bugfix(TDI-38263): fix NPE in Guess Schema feature

### DIFF
--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceConstants.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceConstants.java
@@ -1,0 +1,21 @@
+package org.talend.components.salesforce.runtime;
+
+import org.apache.avro.Schema;
+import org.talend.daikon.avro.AvroUtils;
+
+final public class SalesforceConstants {
+
+    public static final String SALESFORCE_DEFAULT_DATE_PATTERN = "yyyy-MM-dd";
+
+    public static final String REUSE_SESSION_FAILS = "Reuse session fails!";
+
+    public static final Schema DEFAULT_GUESS_SCHEMA_TYPE = AvroUtils._string();
+
+    public static final int DEFAULT_LENGTH = 255;
+
+    public static final int DEFAULT_PRECISION = 15;
+
+    private SalesforceConstants() {
+        throw new AssertionError();
+    }
+}

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSinkTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSinkTest.java
@@ -1,0 +1,119 @@
+package org.talend.components.salesforce.runtime;
+
+import com.sforce.soap.partner.DescribeSObjectResult;
+import com.sforce.soap.partner.Field;
+import com.sforce.soap.partner.FieldType;
+import com.sforce.soap.partner.PartnerConnection;
+import org.apache.avro.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.talend.components.api.container.RuntimeContainer;
+import org.talend.components.salesforce.SalesforceConnectionProperties;
+import org.talend.components.salesforce.runtime.common.ConnectionHolder;
+import org.talend.daikon.avro.AvroUtils;
+import org.talend.daikon.avro.SchemaConstants;
+
+/**
+ * Unit-tests for {@link SalesforceSourceOrSink} class
+ */
+public class SalesforceSourceOrSinkTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SalesforceSourceOrSinkTest.class);
+
+    private static final String SPACE = " ";
+
+    @Mock
+    private RuntimeContainer runtimeContainerMock = Mockito.mock(RuntimeContainer.class);
+
+    private SalesforceConnectionProperties properties;
+
+    @Before
+    public void setUp() throws Exception {
+        properties = new SalesforceConnectionProperties("test");
+    }
+
+    /**
+     * Checks {@link SalesforceSourceOrSink#guessSchema(String)} returns the
+     * {@link org.apache.avro.Schema} with date and string type
+     */
+    @Test
+    public void testGuessSchema() throws Exception {
+        String field0Name = "Id";
+        String field1Name = "LastModifiedDate";
+        String field2Name = "LastActivityDate";
+
+        String drivingEntity = "Account";
+
+        String soql = new StringBuilder().append("SELECT").append(" ")
+                .append(field0Name).append(",").append(SPACE)
+                .append(field1Name).append(",").append(SPACE)
+                .append(field2Name).append(SPACE)
+                .append("FROM").append(SPACE).append(drivingEntity).toString();
+
+        final PartnerConnection partnerConnectionMock = Mockito.mock(PartnerConnection.class);
+
+        class SalesforceSourceOrSinkChild extends SalesforceSourceOrSink {
+            @Override
+            protected ConnectionHolder connect(RuntimeContainer container) {
+                ConnectionHolder connectionHolder = new ConnectionHolder();
+                connectionHolder.connection = partnerConnectionMock;
+                return connectionHolder;
+            }
+        }
+
+        Field field0 = new Field();
+        field0.setName(field0Name);
+        field0.setType(FieldType.string);
+
+        Field field1 = new Field();
+        field1.setName(field1Name);
+        field1.setType(FieldType.date);
+
+        Field field2 = new Field();
+        field2.setName(field2Name);
+        field2.setType(FieldType.date);
+
+        Field[] fields = new Field[3];
+        fields[0] = field0;
+        fields[1] = field1;
+        fields[2] = field2;
+
+        DescribeSObjectResult describeSObjectResult = new DescribeSObjectResult();
+        describeSObjectResult.setFields(fields);
+
+        Mockito.when(partnerConnectionMock.describeSObject(drivingEntity)).thenReturn(describeSObjectResult);
+
+        SalesforceSourceOrSinkChild salesforceSourceOrSinkChild = new SalesforceSourceOrSinkChild();
+        salesforceSourceOrSinkChild.initialize(runtimeContainerMock, properties);
+
+        Schema resultSchema = salesforceSourceOrSinkChild.guessSchema(soql);
+
+        LOGGER.debug("result schema: " + resultSchema.toString());
+
+        Assert.assertEquals("GuessedSchema", resultSchema.getName());
+
+        Assert.assertEquals(field0Name, resultSchema.getFields().get(0).name());
+        Assert.assertEquals("255",
+                resultSchema.getFields().get(0).getProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH));
+
+
+        Assert.assertEquals(field1Name, resultSchema.getFields().get(1).name());
+        Assert.assertEquals("java.util.Date",
+                AvroUtils.unwrapIfNullable(resultSchema.getFields().get(1).schema()).getProp("java-class"));
+        Assert.assertEquals(SalesforceConstants.SALESFORCE_DEFAULT_DATE_PATTERN,
+                resultSchema.getFields().get(1).getProp(SchemaConstants.TALEND_COLUMN_PATTERN));
+
+
+        Assert.assertEquals(field2Name, resultSchema.getFields().get(2).name());
+        Assert.assertEquals("java.util.Date",
+                AvroUtils.unwrapIfNullable(resultSchema.getFields().get(2).schema()).getProp("java-class"));
+        Assert.assertEquals(SalesforceConstants.SALESFORCE_DEFAULT_DATE_PATTERN,
+                resultSchema.getFields().get(2).getProp(SchemaConstants.TALEND_COLUMN_PATTERN));
+    }
+}
+
+


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
NPE when run the job after Guess Schema feature used. There are no default date pattern, length and precision props.   

**What is the new behavior?**
Added default date pattern, length and precision props

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TDI-38263