### PR TITLE
fix: do not exclude transitive guava dependencies for integration test.

### DIFF
--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -26,12 +26,6 @@
             <groupId>org.talend.components</groupId>
             <artifactId>bigquery-definition</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Tests -->


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

`bigquery-integration` fails due to annotation processing when compiling, due to an excluded guava dependency.

**What is the new behavior?**

`bigquery-integration` compiles and tests run successfully.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
