### PR TITLE
fix(TDI-38488): improve response time of SalesforceDataset component

### DIFF
--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
@@ -77,6 +77,7 @@ public class SalesforceDatasetProperties extends PropertiesImpl implements Datas
                 properties.setDatasetProperties(this);
 
                 runtime.initialize(null, properties);
+                runtime.validate(null);
                 List<NamedThing> moduleNames = runtime.getSchemaNames(null);
                 moduleName.setPossibleNamedThingValues(moduleNames);
             }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
@@ -97,7 +97,7 @@ public class SalesforceBulkQueryInputReader extends SalesforceReader<IndexedReco
         String queryText = getQueryString(properties);
         bulkRuntime = new SalesforceBulkRuntime(((SalesforceSource) getCurrentSource()).connect(container).bulkConnection);
         try {
-            bulkRuntime.doBulkQuery(getModuleName(), queryText, 30);
+            bulkRuntime.doBulkQuery(getModuleName(), queryText, 10);
         } catch (AsyncApiException | InterruptedException | ConnectionException e) {
             throw new IOException(e);
         }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
@@ -41,12 +41,13 @@ public class SalesforceBulkQueryInputReader extends SalesforceReader<IndexedReco
         properties = props;
         this.container = container;
     }
-    
+
     @Override
     public boolean start() throws IOException {
         try {
             if (bulkRuntime == null) {
-                bulkRuntime = new SalesforceBulkRuntime(((SalesforceSource) getCurrentSource()).connect(container).bulkConnection);
+                bulkRuntime = new SalesforceBulkRuntime(
+                        ((SalesforceSource) getCurrentSource()).connect(container).bulkConnection);
             }
             executeSalesforceBulkQuery();
             bulkResultSet = bulkRuntime.getQueryResultSet(bulkRuntime.nextResultId());
@@ -97,7 +98,7 @@ public class SalesforceBulkQueryInputReader extends SalesforceReader<IndexedReco
         String queryText = getQueryString(properties);
         bulkRuntime = new SalesforceBulkRuntime(((SalesforceSource) getCurrentSource()).connect(container).bulkConnection);
         try {
-            bulkRuntime.doBulkQuery(getModuleName(), queryText, 10);
+            bulkRuntime.doBulkQuery(getModuleName(), queryText);
         } catch (AsyncApiException | InterruptedException | ConnectionException e) {
             throw new IOException(e);
         }
@@ -111,7 +112,7 @@ public class SalesforceBulkQueryInputReader extends SalesforceReader<IndexedReco
             throw new ComponentException(e);
         }
     }
-    
+
     private String getModuleName() {
         TSalesforceInputProperties inProperties = (TSalesforceInputProperties) properties;
         if (inProperties.manualQuery.getValue()) {

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkRuntime.java
@@ -428,42 +428,45 @@ public class SalesforceBulkRuntime {
         }
         job.setContentType(ContentType.CSV);
         job = createJob(job);
-        job = getJobStatus(job.getId());
+        if (job.getId() == null) { // job creation failed
+            throw new ComponentException(new DefaultErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "failedBatch"),
+                    ExceptionContext.build().put("failedBatch", job));
+        }
 
         ByteArrayInputStream bout = new ByteArrayInputStream(queryStatement.getBytes());
         BatchInfo info = createBatchFromStream(job, bout);
-        int secToWait = 2;
+        int secToWait = 1;
         int tryCount = 0;
         while (true) {
+            LOGGER.debug("Awaiting " + secToWait + " seconds for results ...\n" + info);
+            Thread.sleep(secToWait * 1000);
             info = getBatchInfo(job.getId(), info.getId());
             if (info.getState() == BatchStateEnum.Completed) {
-                QueryResultList list = getQueryResultList(job.getId(), info.getId());
-                queryResultIDs = new HashSet<String>(Arrays.asList(list.getResult())).iterator();
                 break;
             } else if (info.getState() == BatchStateEnum.Failed) {
                 throw new ComponentException(new DefaultErrorCode(HttpServletResponse.SC_BAD_REQUEST, "failedBatch"),
                         ExceptionContext.build().put("failedBatch", info));
             }
-
             tryCount++;
-            if (tryCount % 5 == 0) {// after 5 attemp to get the result we increase the time to wait by 2
-                secToWait = secToWait * 2;
+            if (tryCount % 3 == 0) {// after 3 attempt to get the result we multiply the time to wait by 2
+                secToWait = secToWait * 3;
             }
-            // Number of attempts to query 15 attempts at 10 minutes each to process the batch. There is also a 2-minute limit on
-            // the time to process the query. If more than 15 attempts are made for the query, an error message of “Tried more
-            // than fifteen times” is returned. If the query takes more than 2 minutes to process, a QUERY_TIMEOUT error is
-            // returned.
+            // There is also a 2-minute limit on the time to process the query.
+            // If the query takes more than 2 minutes to process, a QUERY_TIMEOUT error is returned.
             // https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_concepts_limits.htm
-            if (secToWait > 120 || tryCount > 15) {
+            int processingTime = (int) ((System.currentTimeMillis() - job.getCreatedDate().getTimeInMillis()) / 1000);
+            if (processingTime > 120) {
                 throw new ComponentException(new DefaultErrorCode(HttpServletResponse.SC_REQUEST_TIMEOUT, "failedBatch"),
                         ExceptionContext.build().put("failedBatch", info));
             }
-            LOGGER.info("Awaiting " + secToWait + " seconds for results ...\n" + info);
-            Thread.sleep(secToWait * 1000);
         }
+
+        closeJob();
+        QueryResultList list = getQueryResultList(job.getId(), info.getId());
+        queryResultIDs = new HashSet<String>(Arrays.asList(list.getResult())).iterator();
         batchInfoList = new ArrayList<BatchInfo>();
         batchInfoList.add(info);
-        closeJob();
+
     }
 
     public BulkResultSet getQueryResultSet(String resultId) throws AsyncApiException, IOException, ConnectionException {

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
@@ -119,7 +119,7 @@ public final class SalesforceBulkQueryReader extends AbstractBoundedReader<Index
     protected void executeSalesforceBulkQuery() throws IOException, ConnectionException {
         String queryText = getQueryString();
         try {
-            bulkRuntime.doBulkQuery(getModuleName(), queryText, 10);
+            bulkRuntime.doBulkQuery(getModuleName(), queryText);
         } catch (AsyncApiException | InterruptedException | ConnectionException e) {
             throw new IOException(e);
         }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
@@ -18,8 +18,6 @@ import java.util.NoSuchElementException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.talend.components.api.component.runtime.AbstractBoundedReader;
 import org.talend.components.api.component.runtime.Result;
 import org.talend.components.api.container.RuntimeContainer;
@@ -30,6 +28,7 @@ import org.talend.components.salesforce.dataset.SalesforceDatasetProperties.Sour
 import org.talend.components.salesforce.runtime.BulkResult;
 import org.talend.components.salesforce.runtime.BulkResultSet;
 import org.talend.components.salesforce.runtime.SalesforceBulkRuntime;
+import org.talend.components.salesforce.runtime.common.ConnectionHolder;
 import org.talend.components.salesforce.soql.SoqlQuery;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.converter.IndexedRecordConverter;
@@ -38,8 +37,6 @@ import com.sforce.async.AsyncApiException;
 import com.sforce.ws.ConnectionException;
 
 public final class SalesforceBulkQueryReader extends AbstractBoundedReader<IndexedRecord> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SalesforceBulkQueryReader.class);
 
     private SalesforceBulkRuntime bulkRuntime;
 
@@ -71,8 +68,8 @@ public final class SalesforceBulkQueryReader extends AbstractBoundedReader<Index
     public boolean start() throws IOException {
         try {
             if (bulkRuntime == null) {
-                bulkRuntime = new SalesforceBulkRuntime(
-                        ((SalesforceDataprepSource) getCurrentSource()).connect(container).bulkConnection);
+                ConnectionHolder connectionHolder = ((SalesforceDataprepSource) getCurrentSource()).getConnectionHolder();
+                bulkRuntime = new SalesforceBulkRuntime(connectionHolder.bulkConnection);
             }
             executeSalesforceBulkQuery();
             bulkResultSet = bulkRuntime.getQueryResultSet(bulkRuntime.nextResultId());
@@ -121,10 +118,8 @@ public final class SalesforceBulkQueryReader extends AbstractBoundedReader<Index
 
     protected void executeSalesforceBulkQuery() throws IOException, ConnectionException {
         String queryText = getQueryString();
-        bulkRuntime = new SalesforceBulkRuntime(
-                ((SalesforceDataprepSource) getCurrentSource()).connect(container).bulkConnection);
         try {
-            bulkRuntime.doBulkQuery(getModuleName(), queryText, 30);
+            bulkRuntime.doBulkQuery(getModuleName(), queryText, 10);
         } catch (AsyncApiException | InterruptedException | ConnectionException e) {
             throw new IOException(e);
         }
@@ -152,7 +147,7 @@ public final class SalesforceBulkQueryReader extends AbstractBoundedReader<Index
     }
 
     private String getQueryString() throws IOException {
-        if(dataset.sourceType.getValue() == SourceType.MODULE_SELECTION) {
+        if (dataset.sourceType.getValue() == SourceType.MODULE_SELECTION) {
             StringBuilder sb = new StringBuilder();
             sb.append("select ");
             int count = 0;
@@ -171,7 +166,7 @@ public final class SalesforceBulkQueryReader extends AbstractBoundedReader<Index
     }
 
     private String getModuleName() {
-        if(dataset.sourceType.getValue() == SourceType.MODULE_SELECTION) {
+        if (dataset.sourceType.getValue() == SourceType.MODULE_SELECTION) {
             return dataset.moduleName.getValue();
         } else {
             String query = dataset.query.getValue();

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
@@ -82,8 +82,7 @@ public final class SalesforceDataprepSource
         datastore = dataset.getDatastoreProperties();
 
         String config_file = System.getProperty(CONFIG_FILE_lOCATION_KEY);
-        try (InputStream is = config_file != null ? (new FileInputStream(config_file))
-                : this.getClass().getClassLoader().getResourceAsStream("salesforce.properties")) {
+        try (InputStream is = config_file != null ? (new FileInputStream(config_file)) : null) {
             if (is == null) {
                 LOG.warn("not found the property file, will use the default value for endpoint and timeout");
                 return ValidationResult.OK;

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
@@ -55,6 +55,8 @@ import com.sforce.ws.SessionRenewer;
 public final class SalesforceDataprepSource
         implements BoundedSource, SalesforceRuntimeSourceOrSink, SalesforceSchemaHelper<Schema> {
 
+    private static final long serialVersionUID = 1930140572051028338L;
+
     private static final Logger LOG = LoggerFactory.getLogger(SalesforceDataprepSource.class);
 
     private static final String CONFIG_FILE_lOCATION_KEY = "org.talend.component.salesforce.config.file";
@@ -68,6 +70,8 @@ public final class SalesforceDataprepSource
     private SalesforceDatastoreProperties datastore;
 
     private String endpoint = SalesforceConnectionProperties.URL;
+
+    private ConnectionHolder connectionHolder;
 
     private int timeout = DEFAULT_TIMEOUT;
 
@@ -105,6 +109,16 @@ public final class SalesforceDataprepSource
     }
 
     @Override
+    public ValidationResult validate(RuntimeContainer container) {
+        try {
+            connectionHolder = connect(container);
+        } catch (IOException ex) {
+            return SalesforceRuntimeCommon.exceptionToValidationResult(ex);
+        }
+        return ValidationResult.OK;
+    }
+
+    @Override
     public List<? extends BoundedSource> splitIntoBundles(long desiredBundleSizeBytes, RuntimeContainer adaptor)
             throws Exception {
         List<BoundedSource> list = new ArrayList<>();
@@ -129,29 +143,18 @@ public final class SalesforceDataprepSource
 
     @Override
     public List<NamedThing> getSchemaNames(RuntimeContainer container) throws IOException {
-        return SalesforceRuntimeCommon.getSchemaNames(connect(container).connection);
+        return SalesforceRuntimeCommon.getSchemaNames(connectionHolder.connection);
     }
 
     @Override
     public Schema getEndpointSchema(RuntimeContainer container, String schemaName) throws IOException {
         try {
             DescribeSObjectResult[] describeSObjectResults = new DescribeSObjectResult[0];
-            describeSObjectResults = connect(container).connection.describeSObjects(new String[] { schemaName });
+            describeSObjectResults = connectionHolder.connection.describeSObjects(new String[] { schemaName });
             return SalesforceAvroRegistryString.get().inferSchema(describeSObjectResults[0]);
         } catch (ConnectionException e) {
             throw new IOException(e);
         }
-    }
-
-    @Override
-    public ValidationResult validate(RuntimeContainer container) {
-        ValidationResult vr = new ValidationResult();
-        try {
-            connect(container);
-        } catch (IOException ex) {
-            return SalesforceRuntimeCommon.exceptionToValidationResult(ex);
-        }
-        return vr;
     }
 
     ConnectionHolder connect(RuntimeContainer container) throws IOException {
@@ -170,7 +173,6 @@ public final class SalesforceDataprepSource
 
         // Notes on how to test this
         // http://thysmichels.com/2014/02/15/salesforce-wsc-partner-connection-session-renew-when-session-timeout/
-
         config.setSessionRenewer(new SessionRenewer() {
 
             @Override
@@ -190,8 +192,7 @@ public final class SalesforceDataprepSource
         });
 
         config.setConnectionTimeout(timeout);
-
-        config.setCompression(false);
+        config.setCompression(true);// This should only be false when doing debugging.
         config.setUseChunkedPost(true);
         config.setValidateSchema(false);
 
@@ -224,8 +225,7 @@ public final class SalesforceDataprepSource
         String api_version = "34.0";
         String restEndpoint = soapEndpoint.substring(0, soapEndpoint.indexOf("Soap/")) + "async/" + api_version;
         bulkConfig.setRestEndpoint(restEndpoint);
-        // This should only be false when doing debugging.
-        bulkConfig.setCompression(false);
+        bulkConfig.setCompression(true);// This should only be false when doing debugging.
         bulkConfig.setTraceMessage(false);
         bulkConfig.setValidateSchema(false);
         try {
@@ -246,7 +246,7 @@ public final class SalesforceDataprepSource
         DescribeSObjectResult describeSObjectResult = null;
 
         try {
-            describeSObjectResult = connect(null).connection.describeSObject(drivingEntityName);
+            describeSObjectResult = connectionHolder.connection.describeSObject(drivingEntityName);
         } catch (ConnectionException e) {
             throw new RuntimeException(e.getMessage());
         }
@@ -287,5 +287,9 @@ public final class SalesforceDataprepSource
     public String guessQuery(Schema schema, String entityName) {
         // not necessary for dataprep
         return null;
+    }
+
+    public ConnectionHolder getConnectionHolder() {
+        return connectionHolder;
     }
 }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatasetRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatasetRuntime.java
@@ -57,6 +57,7 @@ public class SalesforceDatasetRuntime implements DatasetRuntime<SalesforceDatase
         properties.setDatasetProperties(dataset);
 
         sds.initialize(container, properties);
+        sds.validate(container);
 
         try {
             // TODO the UI will be a radio, need to adjust here

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceInputTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceInputTestIT.java
@@ -39,6 +39,7 @@ public class SalesforceInputTestIT {
 
             SalesforceDataprepSource source = new SalesforceDataprepSource();
             source.initialize(null, properties);
+            source.validate(null);
             reader = source.createReader(null);
 
             reader.start();
@@ -74,6 +75,7 @@ public class SalesforceInputTestIT {
 
         SalesforceDataprepSource source = new SalesforceDataprepSource();
         source.initialize(null, properties);
+        source.validate(null);
         Reader reader = source.createReader(null);
 
         try {
@@ -103,6 +105,7 @@ public class SalesforceInputTestIT {
 
             SalesforceDataprepSource source = new SalesforceDataprepSource();
             source.initialize(null, properties);
+            source.validate(null);
             reader = source.createReader(null);
 
             reader.start();
@@ -139,6 +142,7 @@ public class SalesforceInputTestIT {
 
         SalesforceDataprepSource source = new SalesforceDataprepSource();
         source.initialize(null, properties);
+        source.validate(null);
         Reader reader = source.createReader(null);
 
         try {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38488

**What is the new behavior?**
* SalesforceDataset component was making useless connection
* Activate compression
* Handle wait for batch differently: start to sleep only if can't fetch
first and retry again.
*  make the waiting for salesforce batch result "smarter"
We start to wait 2 seconds for 5 attempt then we multiply the wait time by 2 until the result is returned or a timeout is occurred.
* Remove of non existing resource load. this was slowing the initialize() method of SalesforceDataprepSource for no reason because the file *salesforce.properties* dose not exist

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
