### PR TITLE
fix(TFD-1008): Disable committing kafka offsets when no group.id

### DIFF
--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaConnection.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaConnection.java
@@ -73,6 +73,9 @@ public class KafkaConnection {
         String groupID = input.groupID.getValue();
         if (groupID != null && !"".equals(groupID)) {
             props.put(ConsumerConfig.GROUP_ID_CONFIG, groupID);
+        } else {
+            // If there is no consumer group specified, then never commit offsets.
+            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         }
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, input.autoOffsetReset.getValue().toString().toLowerCase());
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

It appears that offsets are still committed when a Kafka input is used without a group.id.  Depending on the logic of the "fake" group.id that is used, this might interfere with subsequent calls to `getSample()`.

**What is the new behavior?**

Ensure that offsets are never committed without a user-specified group.id.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
