### PR TITLE
fix(TDI-38597): don't allow Not operator in the expression table for …

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Predicate.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Predicate.java
@@ -21,8 +21,7 @@ import com.microsoft.azure.storage.table.TableQuery.Operators;
 
 public enum Predicate {
     AND("AND", Operators.AND),
-    OR("OR", Operators.OR),
-    NOT("NOT", Operators.NOT);
+    OR("OR", Operators.OR);
 
     private String displayName;
 

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
@@ -90,7 +90,7 @@ public class FilterExpressionTableTest {
         columns.add(AzureStorageTableProperties.TABLE_PARTITION_KEY);
         functions.add(Comparison.EQUAL.toString());
         values.add("12345");
-        predicates.add(Predicate.NOT.toString());
+        predicates.add(Predicate.AND.toString());
         fieldTypes.add(STRING.toString());
         setTableVals();
         query = fet.generateCombinedFilterConditions();
@@ -148,7 +148,7 @@ public class FilterExpressionTableTest {
         columns.add(AzureStorageTableProperties.TABLE_PARTITION_KEY);
         functions.add(Comparison.EQUAL.toString());
         values.add("12345");
-        predicates.add(Predicate.NOT.toString());
+        predicates.add(Predicate.AND.toString());
         fieldTypes.add(SupportedFieldType.STRING.toString());
         setTableVals();
         assertFalse(fet.generateCombinedFilterConditions().isEmpty());
@@ -197,7 +197,6 @@ public class FilterExpressionTableTest {
     public void testGetOperator() {
         assertEquals(Operators.AND, Predicate.getOperator(Predicate.AND.toString()));
         assertEquals(Operators.OR, Predicate.getOperator(Predicate.OR.toString()));
-        assertEquals(Operators.NOT, Predicate.getOperator(Predicate.NOT.toString()));
     }
 
 }


### PR DESCRIPTION
…tAzureStorageTableInput

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38597


**What is the new behavior?**
We remove the Operator not from the tAzureStorageTableInput filter table. 
we don't support this option for now


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
