### PR TITLE
fix(TCOMP-531): remove default implementation of getFamilies() method

### DIFF
--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputDefinition.java
@@ -68,4 +68,9 @@ public class BigQueryInputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "bigquery";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputDefinition.java
@@ -68,4 +68,9 @@ public class BigQueryOutputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "bigquery";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinition.java
@@ -74,4 +74,9 @@ public class ElasticsearchInputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "elastic";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinition.java
@@ -74,4 +74,9 @@ public class ElasticsearchOutputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "elastic";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputDefinition.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputDefinition.java
@@ -85,4 +85,9 @@ public class HadoopClusterConfigurationInputDefinition extends AbstractComponent
     public Class<? extends ComponentProperties> getPropertyClass() {
         return HadoopClusterConfigurationInputProperties.class;
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputDefinition.java
@@ -76,4 +76,9 @@ public class JDBCInputDefinition extends AbstractComponentDefinition {
     public Property[] getReturnProperties() {
         return new Property[0];
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputDefinition.java
@@ -55,4 +55,9 @@ public class JDBCOutputDefinition extends AbstractComponentDefinition {
     public Class<? extends ComponentProperties> getPropertyClass() {
         return JDBCOutputProperties.class;
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-jms/jms-definition/src/main/java/org/talend/components/jms/input/JmsInputDefinition.java
+++ b/components/components-jms/jms-definition/src/main/java/org/talend/components/jms/input/JmsInputDefinition.java
@@ -56,4 +56,9 @@ public class JmsInputDefinition extends AbstractComponentDefinition {
     public Set<ConnectorTopology> getSupportedConnectorTopologies() {
         return EnumSet.of(ConnectorTopology.OUTGOING);
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-jms/jms-definition/src/main/java/org/talend/components/jms/output/JmsOutputDefinition.java
+++ b/components/components-jms/jms-definition/src/main/java/org/talend/components/jms/output/JmsOutputDefinition.java
@@ -22,7 +22,6 @@ import org.talend.components.api.component.runtime.DependenciesReader;
 import org.talend.components.api.component.runtime.ExecutionEngine;
 import org.talend.components.api.component.runtime.SimpleRuntimeInfo;
 import org.talend.components.api.properties.ComponentProperties;
-import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.runtime.RuntimeInfo;
 
@@ -54,5 +53,10 @@ public class JmsOutputDefinition extends AbstractComponentDefinition {
 
     public Set<ConnectorTopology> getSupportedConnectorTopologies() {
         return EnumSet.of(ConnectorTopology.INCOMING);
+    }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
     }
 }

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputDefinition.java
@@ -69,4 +69,9 @@ public class PubSubInputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "pubsub";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputDefinition.java
@@ -68,4 +68,9 @@ public class PubSubOutputDefinition extends AbstractComponentDefinition {
     public String getIconKey() {
         return "pubsub";
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinition.java
@@ -66,4 +66,9 @@ public class SalesforceInputDefinition extends AbstractComponentDefinition {
     public List<String> getSupportedProducts() {
         return Arrays.asList(SupportedProduct.DATAPREP);
     }
+
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
 }

--- a/core/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
@@ -132,12 +132,6 @@ public abstract class AbstractComponentDefinition extends AbstractTopLevelDefini
     }
 
     @Override
-    public String[] getFamilies() {
-        // Subclass me
-        return new String[] {};
-    }
-
-    @Override
     protected String getI18nPrefix() {
         return "component."; //$NON-NLS-1$
     }

--- a/core/components-api/src/test/java/org/talend/components/api/test/SimpleComponentDefinition.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/SimpleComponentDefinition.java
@@ -102,4 +102,9 @@ public class SimpleComponentDefinition extends AbstractComponentDefinition {
         return null;
     }
 
+    @Override
+    public String[] getFamilies() {
+        return new String[] {};
+    }
+
 }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

There is default implementation of ComponentDefinition.getFamilies(). Due to this developer sometimes forgets to override it. Also this default implementation is not used in subclasses

**What is the new behavior?**

Remove default implementation

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Related https://jira.talendforge.org/browse/TCOMP-531
DO NOT MERGE UNTIL RC RELEASE!