### PR TITLE
fix(TDI-38493): fix the azure table writer feedback

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
@@ -197,6 +197,10 @@ public class AzureStorageTableWriter implements WriterWithFeedback<Result, Index
         if (object == null) {
             return;
         }
+        // initialize feedback collections for the write operation
+        successfulWrites = new ArrayList<>();
+        rejectedWrites = new ArrayList<>();
+
         result.totalCount++;
         inputRecord = (IndexedRecord) object;
         // This for dynamic which would get schema from the first record


### PR DESCRIPTION
the feedback collections need to be initialized before each write operation

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38493

**What is the new behavior?**
the feedback collections need to be initialized before each write operation

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
