### PR TITLE
feature(TDI-38041): protect from SQL injection in TCOMP/JDBC component

### DIFF
--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
@@ -52,12 +52,15 @@ public class JDBCDatasetProperties extends PropertiesImpl
 
     };
 
+    private transient AllSetting setting;
+
     public void afterSourceType() {
         refreshLayout(getForm(Form.MAIN));
     }
 
     public JDBCDatasetProperties(String name) {
         super(name);
+        setting = new AllSetting();
     }
 
     public void updateSchema() {
@@ -113,7 +116,6 @@ public class JDBCDatasetProperties extends PropertiesImpl
 
     @Override
     public AllSetting getRuntimeSetting() {
-        AllSetting setting = new AllSetting();
 
         JDBCDatastoreProperties datastoreProperties = this.getDatastoreProperties();
         setting.setDriverPaths(datastoreProperties.getCurrentDriverPaths());

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/AllSetting.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/AllSetting.java
@@ -83,6 +83,8 @@ public class AllSetting implements Serializable, JDBCAvroRegistryInfluencer {
 
     private String referencedComponentId;
 
+    private Boolean readOnly = false;
+
     private ComponentProperties referencedComponentProperties;
 
     public String getJdbcUrl() {
@@ -320,6 +322,14 @@ public class AllSetting implements Serializable, JDBCAvroRegistryInfluencer {
 
     public void setSchema(Schema schema) {
         this.schema = schema;
+    }
+
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    public Boolean isReadOnly() {
+        return readOnly;
     }
 
 }

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSourceOrSink.java
@@ -28,12 +28,12 @@ import org.talend.components.api.component.runtime.SourceOrSink;
 import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.api.exception.ComponentException;
 import org.talend.components.api.properties.ComponentProperties;
-import org.talend.components.jdbc.avro.JDBCAvroRegistryString;
 import org.talend.components.common.dataset.DatasetProperties;
 import org.talend.components.common.datastore.DatastoreProperties;
 import org.talend.components.jdbc.ComponentConstants;
 import org.talend.components.jdbc.JdbcComponentErrorsCode;
 import org.talend.components.jdbc.RuntimeSettingProvider;
+import org.talend.components.jdbc.avro.JDBCAvroRegistryString;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
 import org.talend.daikon.NamedThing;
 import org.talend.daikon.SimpleNamedThing;
@@ -153,6 +153,7 @@ public class JDBCSourceOrSink implements SourceOrSink {
 
         // connection component
         Connection conn = JdbcRuntimeUtils.createConnection(setting);
+        conn.setReadOnly(setting.isReadOnly());
 
         Boolean autoCommit = setting.getUseAutoCommit();
         if (autoCommit != null && autoCommit) {

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatasetRuntime.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatasetRuntime.java
@@ -43,6 +43,13 @@ public class JDBCDatasetRuntime implements DatasetRuntime<JDBCDatasetProperties>
     @Override
     public ValidationResult initialize(RuntimeContainer container, JDBCDatasetProperties properties) {
         this.dataset = properties;
+        /*
+         * This data set have to be in a read-only mode for dataprep
+         * to deny queries that try to alter data or schemas
+         * this will allow only read statement to be executed with the JDBC connection
+         * this is also a hint to the driver to enable database optimizations
+         */
+        this.dataset.getRuntimeSetting().setReadOnly(true);
         this.container = container;
         return ValidationResult.OK;
     }

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
@@ -27,8 +27,9 @@ import org.talend.components.api.component.runtime.Reader;
 import org.talend.components.api.component.runtime.Result;
 import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.api.exception.ComponentException;
-import org.talend.components.jdbc.avro.JDBCAvroRegistryString;
+import org.talend.components.jdbc.JdbcComponentErrorsCode;
 import org.talend.components.jdbc.RuntimeSettingProvider;
+import org.talend.components.jdbc.avro.JDBCAvroRegistryString;
 import org.talend.components.jdbc.avro.ResultSetStringRecordConverter;
 import org.talend.components.jdbc.runtime.JDBCSource;
 import org.talend.components.jdbc.runtime.setting.AllSetting;
@@ -62,7 +63,7 @@ public class JDBCInputReader extends AbstractBoundedReader<IndexedRecord> {
     private Result result;
 
     private boolean useExistedConnection;
-    
+
     /**
      * Current {@link IndexedRecord} read by this {@link Reader}
      * It is returned in {@link Reader#getCurrent()} method.
@@ -134,6 +135,8 @@ public class JDBCInputReader extends AbstractBoundedReader<IndexedRecord> {
             resultSet = statement.executeQuery(setting.getSql());
 
             return haveNext();
+        } catch (SQLException e) {
+            throw new ComponentException(JdbcComponentErrorsCode.SQL_ERROR, e);
         } catch (Exception e) {
             throw new ComponentException(e);
         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38041

**What is the new behavior?**
we add the read-only option for the jdbc connection setting.
the data set have to be in a read-only mode for dataprep to deny queries that try to alter data or schemas
this will allow only read statement to be executed with the JDBC connection
this is also a hint to the driver to enable database optimizations


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
