### PR TITLE
fix(TCOMP-422): Ensure that the TGT is valid when using kerberos.

### DIFF
--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
@@ -101,8 +101,10 @@ public abstract class UgiDoAs implements Serializable {
 
         @Override
         public <T> T doAs(PrivilegedExceptionAction<T> action) throws Exception {
-            if (ugi == null)
+            if (ugi == null) {
                 ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab);
+            }
+            ugi.checkTGTAndReloginFromKeytab();
             return ugi.doAs(action);
         }
     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Using kerberos with HDFS has an unexpected ticket expiration after 1 day (in the TCOMP service only).

**What is the new behavior?**

We check the ticket expiration and relogin when necessary.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
