### PR TITLE
fix(TDI-38700): Azure storage wizard can't save schema which was checked

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListProperties.java
@@ -106,14 +106,14 @@ public class AzureStorageComponentListProperties extends ComponentPropertiesImpl
         selectedContainerNames.setPossibleValues(connection.BlobSchema);
         getForm(FORM_CONTAINER).setAllowBack(true);
         getForm(FORM_CONTAINER).setAllowForward(true);
-        getForm(FORM_CONTAINER).setAllowFinish(true);
+        getForm(FORM_CONTAINER).setAllowFinish(false);
     }
 
     public void beforeFormPresentQueue(){
         selectedQueueNames.setPossibleValues(connection.QueueSchema);
         getForm(FORM_QUEUE).setAllowBack(true);
         getForm(FORM_QUEUE).setAllowForward(true);
-        getForm(FORM_QUEUE).setAllowFinish(true);
+        getForm(FORM_QUEUE).setAllowFinish(false);
     }
 
     public void beforeFormPresentTable(){
@@ -124,6 +124,7 @@ public class AzureStorageComponentListProperties extends ComponentPropertiesImpl
 
     public ValidationResult afterFormFinishTable(Repository<Properties> repo) throws Exception {
         String repoLoc = repo.storeProperties(connection, connection.name.getValue(), repositoryLocation, null);
+
         String storeId;
         if (selectedContainerNames.getValue() != null) {
             for (NamedThing nl : selectedContainerNames.getValue()) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-38700
the user can finish the wizard at any point and this cause some schema lo be lost

**What is the new behavior?**
We force the user to go through all wizard pages to preserve the already selected schema

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
