### PR TITLE
fix(TFD-1241): Don't require keytab on worker nodes for fileio (maintenance/0.18)

### DIFF
--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/apache/beam/sdk/io/hdfs/ConfigurableHDFSFileSink.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/apache/beam/sdk/io/hdfs/ConfigurableHDFSFileSink.java
@@ -70,7 +70,7 @@ import org.apache.beam.sdk.repackaged.com.google.common.collect.Sets;
  * Copied from https://github.com/apache/beam/commit/89cf4613465647e2711983674879afd5f67c519d
  * 
  * This class was modified to add the {@link HDFSWriter#configure(Job)} method, and to use the path when getting the
- * filesystem.
+ * filesystem, and to prevent the filesystem from being cached in the components service.
  *
  * A {@code Sink} for writing records to a Hadoop filesystem using a Hadoop file-based output
  * format.
@@ -130,6 +130,7 @@ public class ConfigurableHDFSFileSink<K, V> extends Sink<KV<K, V>> {
         for (Map.Entry<String, String> entry : map.entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }
+        conf.set("fs.hdfs.impl.disable.cache", "true");
         job.setJobID(jobId);
         return job;
     }

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/apache/beam/sdk/io/hdfs/ConfigurableHDFSFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/apache/beam/sdk/io/hdfs/ConfigurableHDFSFileSource.java
@@ -172,6 +172,7 @@ public class ConfigurableHDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
         for (Map.Entry<String, String> entry : map.entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }
+        conf.set("fs.hdfs.impl.disable.cache", "true");
         return job;
     }
 

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ConfigureWithSampleHDFSWriter.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ConfigureWithSampleHDFSWriter.java
@@ -41,6 +41,10 @@ public class ConfigureWithSampleHDFSWriter<K, V> extends ConfigurableHDFSFileSin
         this.uId = uId;
     }
 
+    protected void superOpen(String uId) throws Exception {
+        super.open(uId);
+    }
+
     @Override
     public void write(KV<K, V> value) throws Exception {
         // Open on the first write.
@@ -48,7 +52,7 @@ public class ConfigureWithSampleHDFSWriter<K, V> extends ConfigurableHDFSFileSin
             opened = true;
             // Ensure that a sample is available during open, and clean it up after.
             sample = value;
-            super.open(uId);
+            superOpen(uId);
             sample = null;
         }
         super.write(value);

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/UgiFileSourceBase.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/UgiFileSourceBase.java
@@ -88,14 +88,13 @@ public abstract class UgiFileSourceBase<K, V, SourceT extends UgiFileSourceBase<
     @Override
     public final List<? extends BoundedSource<KV<K, V>>> splitIntoBundles(final long desiredBundleSizeBytes,
             final PipelineOptions options) throws Exception {
-        return doAs.doAs(new PrivilegedExceptionAction<List<? extends BoundedSource<KV<K, V>>>>() {
+            return doAs.doAs(new PrivilegedExceptionAction<List<? extends BoundedSource<KV<K, V>>>>() {
 
-            @Override
-            public List<? extends BoundedSource<KV<K, V>>> run() throws Exception {
-                return doAsSplitIntoBundles(desiredBundleSizeBytes, options);
-            }
-        });
-
+                @Override
+                public List<? extends BoundedSource<KV<K, V>>> run() throws Exception {
+                    return doAsSplitIntoBundles(desiredBundleSizeBytes, options);
+                }
+            });
     }
 
     private long doAsGetEstimatedSizeBytes(final PipelineOptions options) {


### PR DESCRIPTION
The spec required the keytab to be installed on every worker node in the cluster, which is impractical for some clients.  Applying this patch causes the HDFS delegation token to be created on the driver for the principal/keytab and serialized to the nodes where it is reconstituted for all HDFS actions.

Since tokens are never reused with this system, it should also fix TCOMP-422

**What is the current behavior?** (You can also link to an open issue here)

TCOMP-422 (Delegation tokens expire on the TCOMP after a timeout of ~24 hours).
TFD-1241 (Keytabs must be installed on every worker node in the cluster).

**What is the new behavior?**

HDFS delegation token to be created on the driver for the principal/keytab and serialized to the nodes where it is reconstituted for all HDFS actions.  Delegation tokens are not reused between different calls to the TCOMP service.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
