### PR TITLE
fix(TFD-1018): Do no use the REJECT name for Replicate.

### DIFF
--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/replicate/ReplicateProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/replicate/ReplicateProperties.java
@@ -38,7 +38,7 @@ public class ReplicateProperties extends FixedConnectorsComponentProperties {
     // output schema
     public transient PropertyPathConnector FLOW_CONNECTOR = new PropertyPathConnector(Connector.MAIN_NAME, "schemaFlow");
 
-    public transient PropertyPathConnector SECOND_FLOW_CONNECTOR = new PropertyPathConnector(Connector.REJECT_NAME,
+    public transient PropertyPathConnector SECOND_FLOW_CONNECTOR = new PropertyPathConnector(Connector.MAIN_NAME + "2",
             "schemaSecondFlow");
 
     public SchemaProperties schemaFlow = new SchemaProperties("schemaFlow");


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

One of the output connectors on the Replicate component is "REJECT", which doesn't make sense.

**What is the new behavior?**

Renamed the connector "MAIN2" (two connectors can't have the same name).

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
