### PR TITLE
bugfix(TDP-3980)_filter_picklist_fields_with_parent

### DIFF
--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryString.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryString.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.avro.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.salesforce.runtime.SalesforceSchemaConstants;
 import org.talend.daikon.avro.AvroRegistry;
 import org.talend.daikon.avro.AvroUtils;
@@ -56,8 +57,12 @@ public class SalesforceAvroRegistryString extends AvroRegistry {
     private Schema inferSchemaDescribeSObjectResult(DescribeSObjectResult in) {
         List<Schema.Field> fields = new ArrayList<>();
         for (Field field : in.getFields()) {
-            // filter the invalud compound columns for salesforce bulk query api
-            if (field.getType() == FieldType.address || field.getType() == FieldType.location) {
+
+            // filter the invalid compound columns for salesforce bulk query api
+            if (field.getType() == FieldType.address || // no address
+                    field.getType() == FieldType.location || // no location
+                    // no picklist that has a parent
+                    (field.getType() == FieldType.picklist && StringUtils.isNotBlank(field.getCompoundFieldName()))) {
                 continue;
             }
 

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryStringTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryStringTest.java
@@ -2,6 +2,7 @@ package org.talend.components.salesforce.runtime.dataprep;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.avro.Schema;
 import org.junit.Test;
@@ -23,6 +24,20 @@ public class SalesforceAvroRegistryStringTest {
         Schema schema = SalesforceAvroRegistryString.get().inferSchema(describeSObjectResult);
 
         assertThat(1, is(schema.getFields().size()));
+    }
+
+    @Test
+    public void testPickListWithParent() throws Exception {
+        DescribeSObjectResult describeSObjectResult = new DescribeSObjectResult();
+        Field pickList = new Field();
+        pickList.setName("pickList");
+        pickList.setType(FieldType.picklist);
+        pickList.setCompoundFieldName("parent");
+        describeSObjectResult.setFields(new Field[] { pickList });
+
+        Schema schema = SalesforceAvroRegistryString.get().inferSchema(describeSObjectResult);
+
+        assertTrue(schema.getFields().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
filter out only salesforce picklist fields with a parent

**What is the current behavior?** (You can also link to an open issue here)
Salesforce picklist fields that have a parent (compound name) are not supported by salesforce bulk API.

**What is the new behavior?**
Salesforce picklist fields that have a parent (compound name) are filtered out


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [X] The code coverage on new code >75%
- [X] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
