### PR TITLE
fix(TDI-38642): don't throw exception when d'n'd component in studio

### DIFF
--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
@@ -33,7 +33,9 @@ public class TMarketoBulkExecDefinition extends MarketoComponentDefinition {
     public RuntimeInfo getRuntimeInfo(ExecutionEngine engine, ComponentProperties properties,
             ConnectorTopology connectorTopology) {
         assertEngineCompatibility(engine);
-        assertConnectorTopologyCompatibility(connectorTopology);
+        if (connectorTopology != ConnectorTopology.NONE) {
+            assertConnectorTopologyCompatibility(connectorTopology);
+        }
         return getCommonRuntimeInfo(this.getClass().getClassLoader(), RUNTIME_SOURCE_CLASS);
     }
 
@@ -46,7 +48,7 @@ public class TMarketoBulkExecDefinition extends MarketoComponentDefinition {
     public Class<? extends ComponentProperties> getPropertyClass() {
         return TMarketoBulkExecProperties.class;
     }
-    
+
     @Override
     public boolean isStartable() {
         return false;

--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
@@ -33,9 +33,7 @@ public class TMarketoBulkExecDefinition extends MarketoComponentDefinition {
     public RuntimeInfo getRuntimeInfo(ExecutionEngine engine, ComponentProperties properties,
             ConnectorTopology connectorTopology) {
         assertEngineCompatibility(engine);
-        if (connectorTopology != ConnectorTopology.NONE) {
-            assertConnectorTopologyCompatibility(connectorTopology);
-        }
+        assertConnectorTopologyCompatibility(connectorTopology);
         return getCommonRuntimeInfo(this.getClass().getClassLoader(), RUNTIME_SOURCE_CLASS);
     }
 

--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinition.java
@@ -44,7 +44,9 @@ public class TMarketoInputDefinition extends MarketoComponentDefinition {
     public RuntimeInfo getRuntimeInfo(ExecutionEngine engine, ComponentProperties properties,
             ConnectorTopology connectorTopology) {
         assertEngineCompatibility(engine);
-        assertConnectorTopologyCompatibility(connectorTopology);
+        if (connectorTopology != ConnectorTopology.NONE) {
+            assertConnectorTopologyCompatibility(connectorTopology);
+        }
         if (ConnectorTopology.INCOMING.equals(connectorTopology)
                 || ConnectorTopology.INCOMING_AND_OUTGOING.equals(connectorTopology)) {
             return getCommonRuntimeInfo(this.getClass().getClassLoader(), RUNTIME_SINK_CLASS);

--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinition.java
@@ -47,7 +47,9 @@ public class TMarketoListOperationDefinition extends MarketoComponentDefinition 
     @Override
     public RuntimeInfo getRuntimeInfo(ExecutionEngine engine, ComponentProperties props, ConnectorTopology connectorTopology) {
         assertEngineCompatibility(engine);
-        assertConnectorTopologyCompatibility(connectorTopology);
+        if (connectorTopology != ConnectorTopology.NONE) {
+            assertConnectorTopologyCompatibility(connectorTopology);
+        }
         return getCommonRuntimeInfo(this.getClass().getClassLoader(), RUNTIME_SINK_CLASS);
     }
 
@@ -61,7 +63,7 @@ public class TMarketoListOperationDefinition extends MarketoComponentDefinition 
         return new Property[] { RETURN_ERROR_MESSAGE_PROP, RETURN_NB_CALL_PROP, RETURN_TOTAL_RECORD_COUNT_PROP,
                 RETURN_SUCCESS_RECORD_COUNT_PROP, RETURN_REJECT_RECORD_COUNT_PROP };
     }
-    
+
     @Override
     public boolean isStartable() {
         return false;

--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
@@ -47,8 +47,7 @@ public class TMarketoOutputDefinition extends MarketoComponentDefinition {
 
     @Override
     public Set<ConnectorTopology> getSupportedConnectorTopologies() {
-        return EnumSet.of(ConnectorTopology.INCOMING, ConnectorTopology.INCOMING_AND_OUTGOING, ConnectorTopology.NONE,
-                ConnectorTopology.OUTGOING);
+        return EnumSet.of(ConnectorTopology.INCOMING, ConnectorTopology.INCOMING_AND_OUTGOING);
     }
 
     @Override

--- a/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
+++ b/components/components-marketo/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
@@ -54,7 +54,9 @@ public class TMarketoOutputDefinition extends MarketoComponentDefinition {
     @Override
     public RuntimeInfo getRuntimeInfo(ExecutionEngine engine, ComponentProperties props, ConnectorTopology connectorTopology) {
         assertEngineCompatibility(engine);
-        assertConnectorTopologyCompatibility(connectorTopology);
+        if (connectorTopology != ConnectorTopology.NONE) {
+            assertConnectorTopologyCompatibility(connectorTopology);
+        }
         return getCommonRuntimeInfo(this.getClass().getClassLoader(), RUNTIME_SINK_CLASS);
     }
 

--- a/components/components-marketo/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinitionTest.java
+++ b/components/components-marketo/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinitionTest.java
@@ -17,8 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +43,7 @@ public class TMarketoOutputDefinitionTest {
 
     @Test
     public void testGetSupportedConnectorTopologies() throws Exception {
-        assertEquals(new HashSet<ConnectorTopology>(Arrays.asList(ConnectorTopology.INCOMING,
-                ConnectorTopology.INCOMING_AND_OUTGOING, ConnectorTopology.NONE, ConnectorTopology.OUTGOING)),
+        assertEquals(EnumSet.of(ConnectorTopology.INCOMING, ConnectorTopology.INCOMING_AND_OUTGOING),
                 def.getSupportedConnectorTopologies());
     }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-38642

**What is the new behavior?**

Don't check the assertion for connector topology when component has just been dropped from palette in the studio.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
