### PR TITLE
feat(TDKN-167):remove refreshProperties and added ref after callback

### DIFF
--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
@@ -175,8 +175,8 @@ public class SalesforceDatasetProperties extends PropertiesImpl implements Datas
     }
 
     /**
-     * the method is called back at many places, even some strange places, so it should work only for basic layout, not some
-     * action which need runtime support.
+     * the method is called back at many places, even some strange places, so it should work only for basic layout, not
+     * some action which need runtime support.
      */
     @Override
     public void refreshLayout(Form form) {
@@ -207,29 +207,32 @@ public class SalesforceDatasetProperties extends PropertiesImpl implements Datas
     }
 
     @Override
-    public void refreshProperties() {
-        try {
-            retrieveModules();
-            retrieveModuleFields();
-        } catch (IOException e) {
-            LOGGER.error("Cannot retrieve modules or field of a module", e);
-        }
-    }
-
-    @Override
     public SalesforceDatastoreProperties getDatastoreProperties() {
         return datastore.getReference();
     }
 
-    @Override
-    public void setDatastoreProperties(SalesforceDatastoreProperties datastoreProperties) {
-        datastore.setReference(datastoreProperties);
+    public void afterDatastore() {
         try {
             retrieveModules();
         } catch (IOException e) {
             LOGGER.error("error getting salesforce modules", e);
             throw new TalendRuntimeException(SalesforceErrorCodes.UNABLE_TO_RETRIEVE_MODULES, e);
         }
+        if (StringUtils.isNotEmpty(moduleName.getValue())) {
+            try {
+                retrieveModuleFields();
+            } catch (IOException e) {
+                LOGGER.error("error getting salesforce modules fields", e);
+                throw new TalendRuntimeException(SalesforceErrorCodes.UNABLE_TO_RETRIEVE_MODULE_FIELDS, e);
+            }
+        } // else no module set so no reason to update fields
+
+    }
+
+    @Override
+    public void setDatastoreProperties(SalesforceDatastoreProperties datastoreProperties) {
+        datastore.setReference(datastoreProperties);
+        afterDatastore();
     }
 
     public enum SourceType {

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesControllerImpl.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesControllerImpl.java
@@ -82,9 +82,11 @@ public class PropertiesControllerImpl implements PropertiesController {
     public ResponseEntity<ValidationResultsDto> validateProperties(PropertiesDto propertiesContainer) {
         Properties properties = propertiesHelpers.propertiesFromDto(propertiesContainer);
         ValidationResult validationResult = properties.getValidationResult();
-        // TODO: I really would prefer return 200 status code any time it process correctly and that the payload determine the
+        // TODO: I really would prefer return 200 status code any time it process correctly and that the payload
+        // determine the
         // result of the analysis.
-        // Here we use 400 return code for perfectly acceptable validation request but results with unaccepted properties.
+        // Here we use 400 return code for perfectly acceptable validation request but results with unaccepted
+        // properties.
         ResponseEntity<ValidationResultsDto> response;
         if (validationResult == null) {
             response = new ResponseEntity<>(new ValidationResultsDto(emptyList()), OK);
@@ -197,7 +199,6 @@ public class PropertiesControllerImpl implements PropertiesController {
             return "{}";
         }
         properties.refreshLayout(properties.getPreferredForm(formName));
-        properties.refreshProperties();
         return jsonSerializationHelper.toJson(formName, properties);
     }
 

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesHelpers.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesHelpers.java
@@ -1,4 +1,4 @@
-//==============================================================================
+// ==============================================================================
 //
 // Copyright (C) 2006-2017 Talend Inc. - www.talend.com
 //
@@ -9,7 +9,7 @@
 // along with this program; if not, write to Talend SA
 // 9 rue Pages 92150 Suresnes, France
 //
-//==============================================================================
+// ==============================================================================
 
 package org.talend.components.service.rest.impl;
 
@@ -36,6 +36,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @Component
 public class PropertiesHelpers {
 
+    private static final boolean CALL_TRIGGERS = true;
+
     @Autowired
     private JsonSerializationHelper jsonSerializationHelper;
 
@@ -46,15 +48,15 @@ public class PropertiesHelpers {
     private ComponentService componentService;
 
     public <T extends Properties> T propertiesFromDto(PropertiesDto propertiesContainer) {
-        T properties = (T) jsonSerializationHelper.toProperties(
-                toInputStream(propertiesContainer.getProperties().toString(), UTF_8));
+        T properties = (T) jsonSerializationHelper
+                .toProperties(toInputStream(propertiesContainer.getProperties().toString(), UTF_8));
         List<ObjectNode> dependencies = propertiesContainer.getDependencies();
         if (dependencies != null && !dependencies.isEmpty()) {
             List<Properties> props = dependencies.stream() //
                     .map(on -> jsonSerializationHelper.toProperties(toInputStream(on.toString(), UTF_8))) //
                     .collect(toList());
             props.add(properties);
-            ReferenceProperties.resolveReferenceProperties(props, definitionServiceDelegate);
+            ReferenceProperties.resolveReferenceProperties(props, definitionServiceDelegate, CALL_TRIGGERS);
         }
         return properties;
     }

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
@@ -14,8 +14,8 @@ package org.talend.components.service.rest.fullexample;
 
 import static com.jayway.restassured.RestAssured.given;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
@@ -36,7 +36,6 @@ import org.talend.daikon.properties.test.PropertiesTestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringTestApp.class, webEnvironment = RANDOM_PORT)
@@ -72,47 +71,42 @@ public class FullExampleComponentTestIT {
 
     @Test
     public void initializeFullExampleDatastoreProperties() throws java.io.IOException {
-        // given
         PropertiesDto properties = new PropertiesDto();
         properties.setProperties(getFullExampleDataStoreProperties());
 
-        // when
-        Response response = given().content(properties).contentType(APPLICATION_JSON_UTF8_VALUE) //
+        given().content(properties).contentType(APPLICATION_JSON_UTF8_VALUE) //
                 .accept(APPLICATION_JSON_UTF8_VALUE) //
                 .expect().statusCode(200).log().ifError() //
-                .post("properties/{definitionName}", DATA_STORE_DEFINITION_NAME);
-
-        // then
-        ObjectNode fullexampleProperties = mapper.readerFor(ObjectNode.class).readValue(response.asInputStream());
-        // should resemble fullexample_data_store_form.json
-        assertNotNull(fullexampleProperties.get("jsonSchema"));
-        assertNotNull(fullexampleProperties.get("properties"));
-        assertNotNull(fullexampleProperties.get("uiSchema"));
-        assertEquals("FullExampleDatastore", fullexampleProperties.get("properties").get("@definitionName").textValue());
+                .when()//
+                .post("properties/{definitionName}", DATA_STORE_DEFINITION_NAME)//
+                .then()//
+                .body("jsonSchema", notNullValue())//
+                .body("properties", notNullValue())//
+                .body("uiSchema", notNullValue())//
+                .body("properties.@definitionName", equalTo("FullExampleDatastore"))//
+        ;
     }
 
     @Test
     public void initializeFullExampleDatasetProperties() throws java.io.IOException {
-        // given
         PropertiesDto propertiesDto = new PropertiesDto();
         propertiesDto.setProperties(getFileAsObjectNode("fullexample_dataset_properties.json"));
         propertiesDto.setDependencies(singletonList(getFullExampleDataStoreProperties()));
         String dataSetDefinitionName = "FullExampleDataset";
 
-        // when
-        Response response = given().content(propertiesDto).contentType(APPLICATION_JSON_UTF8_VALUE) //
+        given().content(propertiesDto).contentType(APPLICATION_JSON_UTF8_VALUE) //
                 .accept(APPLICATION_JSON_UTF8_VALUE) //
                 .expect().statusCode(200).log().ifError() //
-                .post("properties/{definitionName}", dataSetDefinitionName);
-
-        // then
-        ObjectNode fullexampleProperties = mapper.readerFor(ObjectNode.class).readValue(response.asInputStream());
-        assertNotNull(fullexampleProperties.get("jsonSchema"));
-        assertNotNull(fullexampleProperties.get("properties"));
-        assertNotNull(fullexampleProperties.get("uiSchema"));
-        assertEquals("FullExampleDataset", fullexampleProperties.get("properties").get("@definitionName").textValue());
-        assertEquals("hidden", fullexampleProperties.get("uiSchema").get("moduleName").get("ui:widget").textValue());
-        assertEquals("textarea", fullexampleProperties.get("uiSchema").get("query").get("ui:widget").textValue());
+                .when()//
+                .post("properties/{definitionName}", dataSetDefinitionName)//
+                .then()//
+                .body("jsonSchema", notNullValue())//
+                .body("properties", notNullValue())//
+                .body("uiSchema", notNullValue())//
+                .body("properties.@definitionName", equalTo("FullExampleDataset"))//
+                .body("uiSchema.moduleName.'ui:widget'", equalTo("hidden"))//
+                .body("uiSchema.query.'ui:widget'", equalTo("textarea"))//
+        ;
     }
 
     private ObjectNode getFileAsObjectNode(String file) throws java.io.IOException {
@@ -121,24 +115,22 @@ public class FullExampleComponentTestIT {
 
     @Test
     public void testAfterDatastoreCalled() throws java.io.IOException {
-        // given
         PropertiesDto propertiesDto = new PropertiesDto();
         propertiesDto.setProperties(getFileAsObjectNode("fullexample_dataset_properties.json"));
         propertiesDto.setDependencies(singletonList(getFullExampleDataStoreProperties()));
         String dataSetDefinitionName = "FullExampleDataset";
 
-        // when
-        Response response = given().content(propertiesDto).contentType(APPLICATION_JSON_UTF8_VALUE) //
+        given().content(propertiesDto).contentType(APPLICATION_JSON_UTF8_VALUE) //
                 .accept(APPLICATION_JSON_UTF8_VALUE) //
                 .expect().statusCode(200).log().ifError() //
-                .post("properties/{definitionName}", dataSetDefinitionName);
-
-        // then
-        ObjectNode fullexampleProperties = mapper.readerFor(ObjectNode.class).readValue(response.asInputStream());
-        assertNotNull(fullexampleProperties.get("jsonSchema"));
-        assertNotNull(fullexampleProperties.get("properties"));
-        assertNotNull(fullexampleProperties.get("uiSchema"));
-        assertEquals("bar", fullexampleProperties.get("properties").get("testAfterDatastoreTrigger").textValue());
+                .when()//
+                .post("properties/{definitionName}", dataSetDefinitionName)//
+                .then()//
+                .body("jsonSchema", notNullValue())//
+                .body("properties", notNullValue())//
+                .body("uiSchema", notNullValue())//
+                .body("properties.testAfterDatastoreTrigger", equalTo("bar"))//
+        ;
     }
 
 }

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
@@ -12,10 +12,13 @@
 // ============================================================================
 package org.talend.components.service.rest.fullexample;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import static com.jayway.restassured.RestAssured.given;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -26,19 +29,17 @@ import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.talend.components.service.rest.Application;
 import org.talend.components.service.rest.dto.PropertiesDto;
+import org.talend.components.service.spring.SpringTestApp;
 import org.talend.daikon.properties.test.PropertiesTestUtils;
 
-import static com.jayway.restassured.RestAssured.given;
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = SpringTestApp.class, webEnvironment = RANDOM_PORT)
 @TestPropertySource(properties = { "server.contextPath=" })
 public class FullExampleComponentTestIT {
 
@@ -65,8 +66,7 @@ public class FullExampleComponentTestIT {
     }
 
     private ObjectNode getFullExampleDataStoreProperties() throws java.io.IOException {
-        return mapper.readValue(
-                IOUtils.toString(getClass().getResourceAsStream("fullexample_data_store_properties.json")),
+        return mapper.readValue(IOUtils.toString(getClass().getResourceAsStream("fullexample_data_store_properties.json")),
                 ObjectNode.class);
     }
 
@@ -117,6 +117,28 @@ public class FullExampleComponentTestIT {
 
     private ObjectNode getFileAsObjectNode(String file) throws java.io.IOException {
         return mapper.readerFor(ObjectNode.class).readValue(getClass().getResourceAsStream(file));
+    }
+
+    @Test
+    public void testAfterDatastoreCalled() throws java.io.IOException {
+        // given
+        PropertiesDto propertiesDto = new PropertiesDto();
+        propertiesDto.setProperties(getFileAsObjectNode("fullexample_dataset_properties.json"));
+        propertiesDto.setDependencies(singletonList(getFullExampleDataStoreProperties()));
+        String dataSetDefinitionName = "FullExampleDataset";
+
+        // when
+        Response response = given().content(propertiesDto).contentType(APPLICATION_JSON_UTF8_VALUE) //
+                .accept(APPLICATION_JSON_UTF8_VALUE) //
+                .expect().statusCode(200).log().ifError() //
+                .post("properties/{definitionName}", dataSetDefinitionName);
+
+        // then
+        ObjectNode fullexampleProperties = mapper.readerFor(ObjectNode.class).readValue(response.asInputStream());
+        assertNotNull(fullexampleProperties.get("jsonSchema"));
+        assertNotNull(fullexampleProperties.get("properties"));
+        assertNotNull(fullexampleProperties.get("uiSchema"));
+        assertEquals("bar", fullexampleProperties.get("properties").get("testAfterDatastoreTrigger").textValue());
     }
 
 }

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetProperties.java
@@ -11,6 +11,9 @@
 //
 // ============================================================================
 package org.talend.components.service.rest.fullexample.dataset;
+
+import java.io.IOException;
+
 import org.talend.components.common.SchemaProperties;
 import org.talend.components.common.dataset.DatasetProperties;
 import org.talend.components.service.rest.fullexample.datastore.FullExampleDatastoreDefinition;
@@ -22,8 +25,6 @@ import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.properties.property.StringProperty;
-
-import java.io.IOException;
 
 public class FullExampleDatasetProperties extends PropertiesImpl implements DatasetProperties<FullExampleDatastoreProperties> {
 
@@ -43,10 +44,11 @@ public class FullExampleDatasetProperties extends PropertiesImpl implements Data
 
     public SchemaProperties main = new SchemaProperties("main");
 
+    public Property<String> testAfterDatastoreTrigger = PropertyFactory.newString("testAfterDatastoreTrigger").setValue("foo");
+
     public FullExampleDatasetProperties(String name) {
         super(name);
     }
-
 
     public void afterSourceType() throws IOException {
         refreshLayout(getForm(Form.MAIN));
@@ -71,14 +73,13 @@ public class FullExampleDatasetProperties extends PropertiesImpl implements Data
         if (sourceType.getValue() == SourceType.MODULE_SELECTION) {
             form.getWidget(moduleName).setVisible(true);
             moduleName.setRequired(true);
-            //We can not have a hidden field which is required
+            // We can not have a hidden field which is required
             form.getWidget(query).setVisible(false);
             query.setRequired(false);
-        }
-        else if (sourceType.getValue() == SourceType.SOQL_QUERY) {
+        } else if (sourceType.getValue() == SourceType.SOQL_QUERY) {
             form.getWidget(query).setVisible(true);
             query.setRequired();
-            //We can not have a hidden field which is required
+            // We can not have a hidden field which is required
             form.getWidget(moduleName).setVisible(false);
             moduleName.setRequired(false);
         }
@@ -98,5 +99,9 @@ public class FullExampleDatasetProperties extends PropertiesImpl implements Data
     public enum SourceType {
         MODULE_SELECTION,
         SOQL_QUERY
+    }
+
+    public void afterDatastore() {
+        testAfterDatastoreTrigger.setValue("bar");
     }
 }

--- a/services/components-api-service-rest/src/test/resources/org/talend/components/service/rest/fullexample/dataset/messages.properties
+++ b/services/components-api-service-rest/src/test/resources/org/talend/components/service/rest/fullexample/dataset/messages.properties
@@ -2,5 +2,6 @@ property.sourceType.displayName = Source Type
 property.moduleName.displayName = Module Name
 property.selectColumnIds.displayName=Column Selection
 property.query.displayName = Query
+property.testAfterDatastoreTrigger.displayName=
 form.Main.title=Main
 form.Main.displayName=Main


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
rest api and salesforce had a refreshProperties method, a kind of callback that was created has created especially for DP to have some properties initialized after a datastore is set.

**What is the new behavior?**
There is no more custom method but rather using a standard callback (trigger) concept for this behavior.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:
depends on https://github.com/Talend/daikon/pull/246