### PR TITLE
fix(TCOMP-586): Disable FileSystem caching when using Kerberos.

### DIFF
--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
@@ -137,7 +137,14 @@ public abstract class UgiDoAs implements Serializable {
 
                     @Override
                     public Credentials run() throws IOException {
-                        FileSystem.get(new Configuration()).addDelegationTokens("TCOMP", cred);
+                        Configuration conf = new Configuration();
+                        // TODO: We've explicitly listed all the schemas supported here, but the filesystem schema could be dynamically
+                        // generated from the path (resolved against the default name node).
+                        conf.set("fs.gs.impl.disable.cache", "true");
+                        conf.set("fs.s3t.impl.disable.cache", "true");
+                        conf.set("fs.file.impl.disable.cache", "true");
+                        conf.set("fs.hdfs.impl.disable.cache", "true");
+                        FileSystem.get(conf).addDelegationTokens("TCOMP", cred);
                         return cred;
                     }
                 });


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

FileSystem instances can be cached when requesting tokens for a Kerberos-enabled HDFS.

**What is the new behavior?**

FileSystem instances will not be cached when requesting tokens for a Kerberos-enabled HDFS.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No