### PR TITLE
Dsylaiev/tdi 38059 throw runtime exception when query is wrong

### DIFF
--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.avro.generic.IndexedRecord;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -112,7 +113,7 @@ public abstract class JiraReader implements Reader<IndexedRecord> {
         this.resource = resource;
         this.sharedParameters = createSharedParameters();
         this.result = new Result();
-        rest = new Rest(source.getHostPort());
+        setRest(new Rest(source.getHostPort()));
         String userId = source.getUserId();
         if (userId != null && !userId.isEmpty()) {
             rest.setCredentials(userId, source.getUserPassword());
@@ -123,6 +124,14 @@ public abstract class JiraReader implements Reader<IndexedRecord> {
 
         factory = new IssueAdapterFactory();
         factory.setSchema(source.getSchema());
+    }
+
+    /**
+     *
+     * @param rest initialized REST to set
+     */
+    void setRest(Rest rest) {
+        this.rest = rest;
     }
 
     /**

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
@@ -301,7 +301,7 @@ public abstract class JiraReader implements Reader<IndexedRecord> {
     private ComponentException generateJiraException(int code, String errorMessage) {
 
         return new ComponentException(new DefaultErrorCode(code), ExceptionContext.build()
-                .put("message","Can't get response from server, error code is " + code + errorMessage));
+                .put("message", "Can't get response from server, error code is " + code + "\n" + errorMessage));
 
     }
 

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.avro.generic.IndexedRecord;
 import org.joda.time.Instant;
 import org.slf4j.Logger;

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
@@ -228,8 +228,7 @@ public abstract class JiraReader implements Reader<IndexedRecord> {
      * Makes http request to the server and process its response
      *
      * @throws RuntimeException in case of responce code is not SC_OK (200)
-     * @throws IOException in case of exception during http connection
-     *
+     * @throws IOException      in case of exception during http connection
      */
     protected void makeHttpRequest() throws IOException {
         Map<String, Object> parameters = prepareParameters();
@@ -284,8 +283,12 @@ public abstract class JiraReader implements Reader<IndexedRecord> {
     }
 
     private RuntimeException generateJiraException(int code, String errorMessage) {
-        return new RuntimeException("Can't get response from server, error code is " + code + " , error message: " + errorMessage);
+        if (errorMessage.contains("errorMessages")) {
+            errorMessage = errorMessage.substring(errorMessage.indexOf("errorMessages"))
+                    .substring(errorMessage.indexOf("[") + 1, errorMessage.lastIndexOf("]"));
+        }
+        return new RuntimeException(
+                "Can't get response from server, error code is " + code + " , error message: " + errorMessage);
     }
-
 
 }

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
@@ -25,7 +25,9 @@ import java.util.NoSuchElementException;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.talend.components.api.component.runtime.Source;
 import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.api.exception.ComponentException;
@@ -56,6 +58,9 @@ public class JiraReaderTest {
     private JiraSource source;
 
     private TJiraInputProperties properties;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     /**
      * Creates {@link ComponentService} for tests
@@ -131,8 +136,11 @@ public class JiraReaderTest {
         assertEquals(source, currentSource);
     }
 
-    @Test(expected = ComponentException.class)
+    @Test
     public void testThrowComponentExceptionWhenErrorOccurred() throws IOException {
+        thrown.expect(ComponentException.class);
+        thrown.expectMessage("Can't get response from server, error code is 400\nSome error message");
+
         JiraSearchReader jiraReader = new JiraSearchReader(source);
         Rest rest = mock(Rest.class);
 

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
@@ -13,6 +13,10 @@
 package org.talend.components.jira.runtime.reader;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.talend.components.jira.testutils.JiraTestConstants.*;
 
 import java.io.IOException;
@@ -22,12 +26,14 @@ import java.util.NoSuchElementException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.talend.components.api.component.ComponentDefinition;
 import org.talend.components.api.component.runtime.Source;
 import org.talend.components.api.container.RuntimeContainer;
+import org.talend.components.api.exception.ComponentException;
 import org.talend.components.api.service.ComponentService;
 import org.talend.components.api.service.common.DefinitionRegistry;
 import org.talend.components.api.service.common.ComponentServiceImpl;
+import org.talend.components.jira.connection.JiraResponse;
+import org.talend.components.jira.connection.Rest;
 import org.talend.components.jira.runtime.JiraSource;
 import org.talend.components.jira.tjirainput.TJiraInputDefinition;
 import org.talend.components.jira.tjirainput.TJiraInputProperties;
@@ -123,5 +129,21 @@ public class JiraReaderTest {
         JiraSource currentSource = jiraReader.getCurrentSource();
         jiraReader.close();
         assertEquals(source, currentSource);
+    }
+
+    @Test(expected = ComponentException.class)
+    public void testThrowComponentExceptionWhenErrorOccurred() throws IOException {
+        JiraSearchReader jiraReader = new JiraSearchReader(source);
+        Rest rest = mock(Rest.class);
+
+        JiraResponse jr = new JiraResponse(400, "Some error message");
+        when(rest.get(anyString(), anyMap())).thenReturn(jr);
+
+
+        jiraReader.setRest(rest);
+
+
+        jiraReader.makeHttpRequest();
+
     }
 }

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
@@ -139,9 +139,7 @@ public class JiraReaderTest {
         JiraResponse jr = new JiraResponse(400, "Some error message");
         when(rest.get(anyString(), anyMap())).thenReturn(jr);
 
-
         jiraReader.setRest(rest);
-
 
         jiraReader.makeHttpRequest();
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

tJiraInput throws StringOutOfBoundsException when query is wrong

**What is the new behavior?**

tJiraInput throws RuntimeException when response code from server != 200

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
