### PR TITLE
feat(TFD-1591): Upgrade beam adapter in TCOMP with beam 2.0

### DIFF
--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -15,7 +15,7 @@
     <name>Component API - Beam Parent POM</name>
 
     <properties>
-        <beam.version>0.6.0-tlnd</beam.version>
+        <beam.version>2.0.0</beam.version>
     </properties>
 
     <!-- Necessary if you want to compile with a SNAPSHOT of beam. -->
@@ -44,7 +44,12 @@
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
-                <version>1.1</version>
+                <version>1.4.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>1.0-rc2</version>
             </dependency>
 
             <!-- extensions -->
@@ -56,6 +61,11 @@
             <dependency>
                 <groupId>org.apache.beam</groupId>
                 <artifactId>beam-sdks-java-extensions-sorter</artifactId>
+                <version>${beam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-extensions-google-cloud-platform-core</artifactId>
                 <version>${beam.version}</version>
             </dependency>
             <!-- runners -->

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>beam-sdks-java-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-extensions-google-cloud-platform-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.talend.daikon</groupId>
             <artifactId>daikon</artifactId>
         </dependency>
@@ -27,6 +31,11 @@
         <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompBoundedSourceAdapter.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompBoundedSourceAdapter.java
@@ -40,7 +40,7 @@ public class TCompBoundedSourceAdapter extends BoundedSource<IndexedRecord> {
     }
 
     @Override
-    public List<? extends BoundedSource<IndexedRecord>> splitIntoBundles(long desiredBundleSizeBytes, PipelineOptions options)
+    public List<? extends BoundedSource<IndexedRecord>> split(long desiredBundleSizeBytes, PipelineOptions options)
             throws Exception {
         List<? extends org.talend.components.api.component.runtime.BoundedSource> boundedSources = tCompSource
                 .splitIntoBundles(desiredBundleSizeBytes, null);

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompSinkAdapter.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompSinkAdapter.java
@@ -14,104 +14,19 @@
 package org.talend.components.adapter.beam;
 
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.io.Sink;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.talend.components.api.component.runtime.Result;
-
-import java.util.Map;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
 
 /**
  * Make the TCOMP Sink work on Beam runtime, wrapper it with relate beam interface
  * TCOMP Sink must be serializable
  */
-public class TCompSinkAdapter extends Sink<IndexedRecord> {
+public class TCompSinkAdapter extends PTransform<PCollection<IndexedRecord>, PDone> {
 
-    private org.talend.components.api.component.runtime.Sink tCompSink;
-
-    public TCompSinkAdapter(org.talend.components.api.component.runtime.Sink tCompSink) {
-        this.tCompSink = tCompSink;
-    }
-
+    //TODO(bchen) implement this SinkAdapter by PTransform/ParDo/DoFn
     @Override
-    public void validate(PipelineOptions options) {
-        tCompSink.validate(null);
-    }
-
-    @Override
-    public WriteOperation<IndexedRecord, ?> createWriteOperation(PipelineOptions options) {
-        return new TCompWriteOperationAdapter(tCompSink.createWriteOperation(), this);
-    }
-
-    public static class TCompWriteOperationAdapter extends Sink.WriteOperation<IndexedRecord, Result> {
-
-        private org.talend.components.api.component.runtime.WriteOperation<Result> tCompWriteOperation;
-
-        private TCompSinkAdapter sink;
-
-        public TCompWriteOperationAdapter(org.talend.components.api.component.runtime.WriteOperation tCompWriteOperation,
-                TCompSinkAdapter sink) {
-            this.tCompWriteOperation = tCompWriteOperation;
-            this.sink = sink;
-        }
-
-        @Override
-        public void initialize(PipelineOptions options) throws Exception {
-            tCompWriteOperation.initialize(null);
-        }
-
-        @Override
-        public void finalize(Iterable<Result> writerResults, PipelineOptions options) throws Exception {
-            //TODO store the result somewhere?
-            Map<String, Object> results = tCompWriteOperation.finalize(writerResults, null);
-        }
-
-        @Override
-        public Sink.Writer<IndexedRecord, Result> createWriter(PipelineOptions options) throws Exception {
-            return new TCompWriterAdapter(tCompWriteOperation.createWriter(null), this);
-        }
-
-        @Override
-        public Sink<IndexedRecord> getSink() {
-            return sink;
-        }
-
-        public Coder<Result> getWriterResultCoder() {
-            return SerializableCoder.of(Result.class);
-        }
-    }
-
-    public static class TCompWriterAdapter extends Sink.Writer<IndexedRecord, Result> {
-
-        private org.talend.components.api.component.runtime.Writer<Result> tCompWriter;
-
-        private TCompWriteOperationAdapter wo;
-
-        public TCompWriterAdapter(org.talend.components.api.component.runtime.Writer<Result> tCompWriter,
-                TCompWriteOperationAdapter wo) {
-            this.tCompWriter = tCompWriter;
-            this.wo = wo;
-        }
-
-        @Override
-        public void open(String uId) throws Exception {
-            tCompWriter.open(uId);
-        }
-
-        @Override
-        public void write(IndexedRecord value) throws Exception {
-            tCompWriter.write(value);
-        }
-
-        @Override
-        public Result close() throws Exception {
-            return tCompWriter.close();
-        }
-
-        @Override
-        public WriteOperation<IndexedRecord, Result> getWriteOperation() {
-            return wo;
-        }
+    public PDone expand(PCollection<IndexedRecord> input) {
+        return null;
     }
 }

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoderProviderRegistrar.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoderProviderRegistrar.java
@@ -1,0 +1,34 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.components.adapter.beam.coders;
+
+import java.util.List;
+
+import org.apache.beam.sdk.coders.CoderProvider;
+import org.apache.beam.sdk.coders.CoderProviderRegistrar;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A {@link CoderProviderRegistrar} for {@link LazyAvroCoder}.
+ */
+@AutoService(CoderProviderRegistrar.class)
+public class LazyAvroCoderProviderRegistrar implements CoderProviderRegistrar {
+
+    @Override
+    public List<CoderProvider> getCoderProviders() {
+        return ImmutableList.of(LazyAvroCoder.getCoderProvider());
+    }
+}

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/GcpServiceAccountOptions.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/GcpServiceAccountOptions.java
@@ -13,9 +13,8 @@
 
 package org.talend.components.adapter.beam.gcp;
 
-import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.Description;
-import org.apache.beam.sdk.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /**

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/ServiceAccountCredentialFactory.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/ServiceAccountCredentialFactory.java
@@ -19,9 +19,9 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.beam.sdk.extensions.gcp.auth.CredentialFactory;
+import org.apache.beam.sdk.extensions.gcp.auth.GcpCredentialFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.util.CredentialFactory;
-import org.apache.beam.sdk.util.GcpCredentialFactory;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIO.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIO.java
@@ -173,7 +173,7 @@ public class RowGeneratorIO {
         }
 
         @Override
-        public void validate(PBegin input) {
+        public void validate(PipelineOptions options) {
             checkState(getJsonSchema() != null, "RowGeneratorIO.read() requires a schema" + " to be set via withSchema(schema)");
             checkState(getRows() >= 0, "RowGeneratorIO.read() requires withRows(rows)"
                     + " to be called with a non-negative value.");
@@ -240,7 +240,7 @@ public class RowGeneratorIO {
         }
 
         @Override
-        public List<BoundedRowGeneratorSource> splitIntoBundles(long desiredBundleSizeBytes, PipelineOptions options)
+        public List<BoundedRowGeneratorSource> split(long desiredBundleSizeBytes, PipelineOptions options)
                 throws Exception {
             // The desiredBundleSizeBytes is ignored to split the rows into the bundles specified by the spec.
             if (partitionId != -1) {

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecord.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecord.java
@@ -19,6 +19,8 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.talend.daikon.avro.AvroRegistry;
 import org.talend.daikon.avro.converter.IndexedRecordConverter;
 
@@ -29,11 +31,11 @@ import org.talend.daikon.avro.converter.IndexedRecordConverter;
  * configured to "know" how to interpret technology-specific types (in the current virtual machine).
  *
  * @param <DatumT> The type of the incoming collection.
- * @param <AvroT> If more type information is known about the expected output, it can be included. Otherwise, this
- * should be just an IndexedRecord.
  */
-public class ConvertToIndexedRecord<DatumT, AvroT extends IndexedRecord> extends
-        PTransform<PCollection<DatumT>, PCollection<AvroT>> {
+public class ConvertToIndexedRecord<DatumT> extends
+        PTransform<PCollection<DatumT>, PCollection<IndexedRecord>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConvertToIndexedRecord.class);
 
     /** Use the {@link #of()} method to create. */
     protected ConvertToIndexedRecord() {
@@ -42,32 +44,32 @@ public class ConvertToIndexedRecord<DatumT, AvroT extends IndexedRecord> extends
     /**
      * @return an instance of this transformation.
      */
-    public static <DatumT, AvroT extends IndexedRecord> ConvertToIndexedRecord<DatumT, AvroT> of() {
-        return new ConvertToIndexedRecord<DatumT, AvroT>();
+    public static <DatumT> ConvertToIndexedRecord<DatumT> of() {
+        return new ConvertToIndexedRecord<DatumT>();
     }
 
     /**
      * Converts any datum to an {@link IndexedRecord} representation as if it were passed in the transformation. This
      * might be an expensive call, so it should only be used for sampling data (not in a processing-intensive loop).
-     * 
+     *
      * @param datum the datum to convert.
      * @return its representation as an Avro {@link IndexedRecord}.
      */
-    public static <DatumT, AvroT extends IndexedRecord> AvroT convertToAvro(DatumT datum) {
+    public static <DatumT> IndexedRecord convertToAvro(DatumT datum) {
         IndexedRecordConverter c = new AvroRegistry().createIndexedRecordConverter(datum.getClass());
         if (c == null) {
             throw new Pipeline.PipelineExecutionException(new RuntimeException("Cannot convert " + datum.getClass()
                     + " to IndexedRecord."));
         }
-        return (AvroT) c.convertToAvro(datum);
+        return (IndexedRecord) c.convertToAvro(datum);
     }
 
     @Override
-    public PCollection<AvroT> expand(PCollection<DatumT> input) {
-        return input.apply(ParDo.of(new DoFn<DatumT, AvroT>() {
+    public PCollection<IndexedRecord> expand(PCollection<DatumT> input) {
+        return input.apply(ParDo.of(new DoFn<DatumT, IndexedRecord>() {
 
             /** The converter is cached for performance. */
-            private transient IndexedRecordConverter<? super DatumT, ?> converter;
+            private transient IndexedRecordConverter<? super DatumT, IndexedRecord> converter;
 
             @DoFn.ProcessElement
             public void processElement(ProcessContext c) throws Exception {
@@ -76,7 +78,7 @@ public class ConvertToIndexedRecord<DatumT, AvroT extends IndexedRecord> extends
                     return;
                 }
                 if (converter == null) {
-                    converter = (IndexedRecordConverter<? super DatumT, ? extends IndexedRecord>) new AvroRegistry()
+                    converter = (IndexedRecordConverter<? super DatumT, IndexedRecord>) new AvroRegistry()
                             .createIndexedRecordConverter(in.getClass());
                     // If the converter was still not successful, the pipeline should fail.
                     if (converter == null) {
@@ -84,7 +86,9 @@ public class ConvertToIndexedRecord<DatumT, AvroT extends IndexedRecord> extends
                         throw new RuntimeException("Cannot find converter for " + in.getClass());
                     }
                 }
-                c.output((AvroT) converter.convertToAvro(in));
+                LOG.debug("Converter's schema is {}", converter.getSchema());
+                LOG.debug("Process element is {}", in);
+                c.output(converter.convertToAvro(in));
             }
 
         }));

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecordTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecordTest.java
@@ -24,7 +24,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.Test;
-import org.talend.components.adapter.beam.coders.LazyAvroCoder;
 import org.talend.daikon.avro.converter.SingleColumnIndexedRecordConverter;
 
 /**
@@ -49,13 +48,11 @@ public class ConvertToIndexedRecordTest {
         PipelineOptions options = PipelineOptionsFactory.create();
         options.setRunner(DirectRunner.class);
         final Pipeline p = Pipeline.create(options);
-        // TODO(rskraba): How should this be correctly registered in the pipeline?
-        p.getCoderRegistry().registerCoder(IndexedRecord.class, LazyAvroCoder.coderFactory());
 
         PCollection<String> input = p.apply(Create.of(Arrays.asList(inputValues))); //
 
         // Collect the results before and after the transformation.
-        PCollection<IndexedRecord> output = input.apply(ConvertToIndexedRecord.<String, IndexedRecord> of());
+        PCollection<IndexedRecord> output = input.apply(ConvertToIndexedRecord.<String> of());
 
         // Validate the contents of the collections in the pipeline.
         PAssert.that(input).containsInAnyOrder(inputValues);

--- a/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/pom.xml
+++ b/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <beam.version>0.6.0-tlnd</beam.version>
+        <beam.version>2.0.0</beam.version>
         <tcomp.version>${version}</tcomp.version>
     </properties>
 

--- a/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/src/main/java/runtime__runtimeVersionConverted__/__componentNameClass__DatasetRuntime.java
+++ b/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/src/main/java/runtime__runtimeVersionConverted__/__componentNameClass__DatasetRuntime.java
@@ -70,7 +70,6 @@ public class ${componentNameClass}DatasetRuntime implements DatasetRuntime<${com
         PipelineOptions options = PipelineOptionsFactory.create();
 //        options.setRunner(DirectRunner.class);
         final Pipeline p = Pipeline.create(options);
-        LazyAvroCoder.registerAsFallback(p);
 
         try (DirectConsumerCollector<IndexedRecord> collector = DirectConsumerCollector.of(consumer)) {
             // Collect a sample of the input records.

--- a/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/src/main/java/runtime__runtimeVersionConverted__/__componentNameClass__OutputRuntime.java
+++ b/examples/components-api-archetypes/poc-bd-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime__runtimeVersionConverted__/src/main/java/runtime__runtimeVersionConverted__/__componentNameClass__OutputRuntime.java
@@ -20,7 +20,6 @@ import org.apache.avro.generic.IndexedRecord;
 
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.io.Write;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<hadoop.version>2.7.0</hadoop.version>
-		<beam.version>0.6.0-tlnd</beam.version>
+		<beam.version>2.0.0</beam.version>
 		<!-- Used for Docker images name -->
 		<git_branch>local</git_branch>
 		<docker_tag_suffix>${maven.build.timestamp}</docker_tag_suffix>

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.boot.version>1.5.1.RELEASE</spring.boot.version>
 		<hadoop.version>2.7.0</hadoop.version>
-		<beam.version>0.6.0-tlnd</beam.version>
+		<beam.version>2.0.0</beam.version>
 		<!-- JDBC drivers versions -->
 		<mariadb.driver.version>2.0.2</mariadb.driver.version>
 		<postgresql.driver.version>42.1.1</postgresql.driver.version>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
* Upgrade to Beam 2.0 for all base repo in TCOMP
* small API changes
* CoderRegistry changes, no setFallBack support, use AutoService to registry provider, 
* IndexedRecord as the only accept type between components, if component need other coder, provide themself
* No Sink API in beam anymore, TCompSinkAdapter is not used for the moment, will see if ParDo/DoFn can cover all the situation for component usage when there is a real example. (or it can be removed actually)
! ALL individual components change will be in next PR.


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
