### PR TITLE
fix(TDI-39014): Show error frame instead of throw Exception

### DIFF
--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
@@ -81,7 +81,7 @@ public class SalesforceModuleProperties extends ComponentPropertiesImpl implemen
         this.schemaListener = schemaListener;
     }
 
-    // consider beforeActivate and beforeRender (change after to afterActivate)l
+    // consider beforeActivate and beforeRender (change after to afterActivate)
 
     public ValidationResult beforeModuleName() throws Exception {
         try (SandboxedInstance sandboxedInstance = getSandboxedInstance(SOURCE_OR_SINK_CLASS, USE_CURRENT_JVM_PROPS)) {
@@ -93,10 +93,10 @@ public class SalesforceModuleProperties extends ComponentPropertiesImpl implemen
                     List<NamedThing> moduleNames = ss.getSchemaNames(null);
                     moduleName.setPossibleNamedThingValues(moduleNames);
                 } catch (Exception ex) {
-                    throw new ComponentException(ExceptionUtil.exceptionToValidationResult(ex));
+                    return ExceptionUtil.exceptionToValidationResult(ex);
                 }
             } else {
-                throw new ComponentException(vr);
+                return vr;
             }
             
             return ValidationResult.OK;

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
@@ -29,7 +29,6 @@ import static org.talend.components.salesforce.tsalesforceoutput.TSalesforceOutp
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +43,6 @@ import org.talend.daikon.avro.SchemaConstants;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.properties.PropertiesDynamicMethodHelper;
 import org.talend.daikon.properties.ValidationResult;
-import org.talend.daikon.properties.ValidationResultMutable;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.service.PropertiesService;
 import org.talend.daikon.properties.service.PropertiesServiceImpl;

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
@@ -29,6 +29,7 @@ import static org.talend.components.salesforce.tsalesforceoutput.TSalesforceOutp
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,6 +43,8 @@ import org.talend.components.salesforce.SalesforceTestBase;
 import org.talend.daikon.avro.SchemaConstants;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.properties.PropertiesDynamicMethodHelper;
+import org.talend.daikon.properties.ValidationResult;
+import org.talend.daikon.properties.ValidationResultMutable;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.service.PropertiesService;
 import org.talend.daikon.properties.service.PropertiesServiceImpl;
@@ -150,8 +153,9 @@ public class TSalesforceOutputPropertiesTest extends SalesforceTestBase {
         }
     }
 
-    @Test(expected = TalendRuntimeException.class)
-    public void testBeforeModuleNameException() throws Throwable {
+    @Test
+    public void testBeforeModuleNameErrorWhenExceptionOccurs() throws Throwable {
+        ValidationResult expectedValidationResult = new ValidationResult(ValidationResult.Result.ERROR, "UNEXPECTED_EXCEPTION:{message=ERROR}");
         properties.init();
 
         try (MockRuntimeSourceOrSinkTestFixture testFixture = new MockRuntimeSourceOrSinkTestFixture(
@@ -161,7 +165,10 @@ public class TSalesforceOutputPropertiesTest extends SalesforceTestBase {
             when(testFixture.runtimeSourceOrSink.getSchemaNames(any(RuntimeContainer.class)))
                     .thenThrow(TalendRuntimeException.createUnexpectedException("ERROR"));
 
-            propertiesService.beforePropertyActivate("moduleName", properties.module);
+            ValidationResult actualValidationResult =  propertiesService.beforePropertyActivate("moduleName", properties.module).getValidationResult();
+
+            assertEquals(expectedValidationResult.getStatus(), actualValidationResult.getStatus());
+            assertEquals(expectedValidationResult.getMessage(), actualValidationResult.getMessage());
         }
     }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Component throws exception then something wrong with connection properties (expired password, etc.)
User should check error log to see the reason 

**What is the new behavior?**

Component return ValidationResult.Result.ERROR, so user could see error immediately

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
