### PR TITLE
feat(TFD-2413): Use ACE editor on AVSC defintiion.

### DIFF
--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
@@ -65,7 +65,9 @@ public class KafkaDatasetProperties extends PropertiesImpl implements DatasetPro
         mainForm.addRow(widget(topic).setWidgetType(Widget.NAME_SELECTION_AREA_WIDGET_TYPE));
         mainForm.addRow(valueFormat);
         mainForm.addRow(fieldDelimiter);
-        mainForm.addRow(isHierarchy).addColumn(avroSchema);
+        mainForm.addRow(isHierarchy);
+        mainForm.addRow(widget(avroSchema).setWidgetType(Widget.CODE_WIDGET_TYPE)
+                .setConfigurationValue(Widget.CODE_SYNTAX_WIDGET_CONF, "json"));
         mainForm.addRow(main.getForm(Form.MAIN));
 
     }

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
@@ -22,12 +22,15 @@ import org.talend.daikon.properties.PropertiesImpl;
 import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.ValidationResult;
 import org.talend.daikon.properties.presentation.Form;
+import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.EnumProperty;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.runtime.RuntimeUtil;
 import org.talend.daikon.sandbox.SandboxedInstance;
+
+import static org.talend.daikon.properties.presentation.Widget.widget;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +68,8 @@ public class PubSubDatasetProperties extends PropertiesImpl implements DatasetPr
         mainForm.addRow(subscription);
         mainForm.addRow(valueFormat);
         mainForm.addRow(fieldDelimiter);
-        mainForm.addRow(avroSchema);
+        mainForm.addRow(widget(avroSchema).setWidgetType(Widget.CODE_WIDGET_TYPE)
+                .setConfigurationValue(Widget.CODE_SYNTAX_WIDGET_CONF, "json"));
         // mainForm.addRow(main.getForm(Form.MAIN));
     }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
the PubSub and the Kafka components are using a simple input field to let the user define AVSC.
Since the AVSC are a multi-line format, creating them is not user friendly


**What is the new behavior?**
Change the property to use ACE.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
