### PR TITLE
Bugfix/TFD-2421 Infer the schema from the incoming data

### DIFF
--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputProperties.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputProperties.java
@@ -59,8 +59,8 @@ public class BigQueryOutputProperties extends FixedConnectorsComponentProperties
     @Override
     public void setupProperties() {
         super.setupProperties();
-        tableOperation.setValue(TableOperation.CREATE_IF_NOT_EXISTS);
-        writeOperation.setValue(WriteOperation.WRITE_TO_EMPTY);
+        tableOperation.setValue(TableOperation.NONE);
+        writeOperation.setValue(WriteOperation.APPEND);
     }
 
     @Override

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputPropertiesTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputPropertiesTest.java
@@ -56,8 +56,8 @@ public class BigQueryOutputPropertiesTest {
      */
     @Test
     public void testDefaultProperties() {
-        assertEquals(BigQueryOutputProperties.TableOperation.CREATE_IF_NOT_EXISTS, properties.tableOperation.getValue());
-        assertEquals(BigQueryOutputProperties.WriteOperation.WRITE_TO_EMPTY, properties.writeOperation.getValue());
+        assertEquals(BigQueryOutputProperties.TableOperation.NONE, properties.tableOperation.getValue());
+        assertEquals(BigQueryOutputProperties.WriteOperation.APPEND, properties.writeOperation.getValue());
     }
 
     /**

--- a/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryBeamRuntimeTestIT.java
+++ b/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryBeamRuntimeTestIT.java
@@ -207,7 +207,7 @@ public class BigQueryBeamRuntimeTestIT implements Serializable {
         inputRuntime.initialize(runtimeContainer, inputProperties);
 
         PCollection<TableRow> tableRowPCollection = pipeline.apply(inputRuntime)
-                .apply(ParDo.of(new BigQueryOutputRuntime.IndexedRecordToTableRowFn(schema))).setCoder(TableRowJsonCoder.of());
+                .apply(ParDo.of(new BigQueryOutputRuntime.IndexedRecordToTableRowFn())).setCoder(TableRowJsonCoder.of());
 
         PAssert.that(tableRowPCollection).containsInAnyOrder(rows);
 

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
@@ -65,7 +65,9 @@ public class KafkaDatasetProperties extends PropertiesImpl implements DatasetPro
         mainForm.addRow(widget(topic).setWidgetType(Widget.NAME_SELECTION_AREA_WIDGET_TYPE));
         mainForm.addRow(valueFormat);
         mainForm.addRow(fieldDelimiter);
-        mainForm.addRow(isHierarchy).addColumn(avroSchema);
+        mainForm.addRow(isHierarchy);
+        mainForm.addRow(widget(avroSchema).setWidgetType(Widget.CODE_WIDGET_TYPE)
+                .setConfigurationValue(Widget.CODE_SYNTAX_WIDGET_CONF, "json"));
         mainForm.addRow(main.getForm(Form.MAIN));
 
     }

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
@@ -22,12 +22,15 @@ import org.talend.daikon.properties.PropertiesImpl;
 import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.ValidationResult;
 import org.talend.daikon.properties.presentation.Form;
+import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.EnumProperty;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.runtime.RuntimeUtil;
 import org.talend.daikon.sandbox.SandboxedInstance;
+
+import static org.talend.daikon.properties.presentation.Widget.widget;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +68,8 @@ public class PubSubDatasetProperties extends PropertiesImpl implements DatasetPr
         mainForm.addRow(subscription);
         mainForm.addRow(valueFormat);
         mainForm.addRow(fieldDelimiter);
-        mainForm.addRow(avroSchema);
+        mainForm.addRow(widget(avroSchema).setWidgetType(Widget.CODE_WIDGET_TYPE)
+                .setConfigurationValue(Widget.CODE_SYNTAX_WIDGET_CONF, "json"));
         // mainForm.addRow(main.getForm(Form.MAIN));
     }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
The BigQueryOutput use the metadata schema to put its data into BigQuery. This is not compatible with TFD.


**What is the new behavior?**
The BigQueryOuput will infer the schema from the data.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
