### PR TITLE
Change Daikon version to 0.20.0-SNAPSHOT.

### DIFF
--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -16,7 +16,7 @@
 		<spring.boot.version>1.5.1.RELEASE</spring.boot.version>
 		<avro.version>1.8.1</avro.version>
 		<components.version>0.21.0-SNAPSHOT</components.version>
-		<daikon.version>0.19.0-SNAPSHOT</daikon.version>
+		<daikon.version>0.20.0-SNAPSHOT</daikon.version>
 		<guava.version>19.0</guava.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<org.json.version>20131018</org.json.version>

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -91,12 +91,12 @@
             <artifactId>daikon</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <version>0.19.0-SNAPSHOT</version>
+            <version>0.20.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.talend.daikon</groupId>
             <artifactId>daikon-spring-utils</artifactId>
-            <version>0.19.0-SNAPSHOT</version>
+            <version>0.20.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>service-parent</artifactId>
-        <version>0.19.0-SNAPSHOT</version>
+        <version>0.20.0-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
 
@@ -19,7 +19,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <daikon.version>0.19.0-SNAPSHOT</daikon.version>
+        <daikon.version>0.20.0-SNAPSHOT</daikon.version>
         <!-- Used for Docker images name -->
         <git_branch>local</git_branch>
         <talend_docker_registry>registry.datapwn.com</talend_docker_registry>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.talend.daikon</groupId>
             <artifactId>logging-event-layout</artifactId>
-            <version>0.19.0-SNAPSHOT</version>
+            <version>0.20.0-SNAPSHOT</version>
         </dependency>
 
         <!-- tests dependencies -->


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
The component PreparationRow is going to need some new widget definition that are only available on daikon 0.20.0-SNAPSHOT.


**What is the new behavior?**
Components is now using daikon 0.20.0-SNAPSHOT.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
