### PR TITLE
fix(TDI-40107): show all buckets whatever region they are in and remove the region properties, fetch the region by the bucket name at runtime

### DIFF
--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -102,7 +102,6 @@
                     <systemPropertyVariables>
                         <s3.accesskey>${s3.accesskey}</s3.accesskey>
                         <s3.secretkey>${s3.secretkey}</s3.secretkey>
-                        <s3.region>${s3.region}</s3.region>
                         <s3.bucket>${s3.bucket}</s3.bucket>
                         <s3.ssekmskey>${s3.ssekmskey}</s3.ssekmskey>
                         <s3.csekmskey>${s3.csekmskey}</s3.csekmskey>

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -102,6 +102,7 @@
                     <systemPropertyVariables>
                         <s3.accesskey>${s3.accesskey}</s3.accesskey>
                         <s3.secretkey>${s3.secretkey}</s3.secretkey>
+                        <s3.region>${s3.region}</s3.region>
                         <s3.bucket>${s3.bucket}</s3.bucket>
                         <s3.ssekmskey>${s3.ssekmskey}</s3.ssekmskey>
                         <s3.csekmskey>${s3.csekmskey}</s3.csekmskey>

--- a/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
+++ b/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
@@ -23,8 +23,6 @@ import org.talend.components.simplefileio.s3.output.S3OutputProperties;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
@@ -40,15 +38,15 @@ public class S3Connection {
         com.amazonaws.auth.AWSCredentials credentials = new com.amazonaws.auth.BasicAWSCredentials(
                 data_store.accessKey.getValue(), data_store.secretKey.getValue());
 
-        Region region = RegionUtils.getRegion(data_set.region.getValue().getValue());
         Boolean clientSideEnc = data_set.encryptDataInMotion.getValue();
 
         AmazonS3 conn = null;
         if (clientSideEnc != null && clientSideEnc) {
+            //the code below is not called now
             String kms_cmk = data_set.kmsForDataInMotion.getValue();
             KMSEncryptionMaterialsProvider encryptionMaterialsProvider = new KMSEncryptionMaterialsProvider(kms_cmk);
             conn = new AmazonS3EncryptionClient(credentials, encryptionMaterialsProvider,
-                    new CryptoConfiguration().withAwsKmsRegion(region));
+                    new CryptoConfiguration()/*.withAwsKmsRegion(region)*/);
         } else {
             AWSCredentialsProvider basicCredentialsProvider = new StaticCredentialsProvider(credentials);
             conn = new AmazonS3Client(basicCredentialsProvider);

--- a/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
+++ b/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
@@ -50,7 +50,7 @@ public class S3Connection {
             conn = new AmazonS3Client(basicCredentialsProvider);
         }
 
-        //seems the region is only useful for creating bucket, not necessary for our usage, so remove it, TODO make sure it
+        //seems the region is only useful for creating bucket, not necessary for our usage, so remove it
         //region.setRegion(region);
         return conn;
     }

--- a/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
+++ b/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
@@ -19,8 +19,6 @@ import org.talend.components.simplefileio.s3.output.S3OutputProperties;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
@@ -36,22 +34,24 @@ public class S3Connection {
         com.amazonaws.auth.AWSCredentials credentials = new com.amazonaws.auth.BasicAWSCredentials(
                 data_store.accessKey.getValue(), data_store.secretKey.getValue());
 
-        Region region = RegionUtils.getRegion(data_set.region.getValue().getValue());
         Boolean clientSideEnc = data_set.encryptDataInMotion.getValue();
 
         AmazonS3 conn = null;
         if (clientSideEnc != null && clientSideEnc) {
             String kms_cmk = data_set.kmsForDataInMotion.getValue();
             KMSEncryptionMaterialsProvider encryptionMaterialsProvider = new KMSEncryptionMaterialsProvider(kms_cmk);
+            
+            //TODO check if region is necessry for AWS KMS service here, now the code below is not called
+            //Region region = RegionUtils.getRegion(data_set.region.getValue().getValue());
             conn = new AmazonS3EncryptionClient(credentials, encryptionMaterialsProvider,
-                    new CryptoConfiguration().withAwsKmsRegion(region));
+                    new CryptoConfiguration()/*.withAwsKmsRegion(region)*/);
         } else {
             AWSCredentialsProvider basicCredentialsProvider = new StaticCredentialsProvider(credentials);
             conn = new AmazonS3Client(basicCredentialsProvider);
         }
 
-        conn.setRegion(region);
-
+        //seems the region is only useful for creating bucket, not necessary for our usage, so remove it, TODO make sure it
+        //region.setRegion(region);
         return conn;
     }
 

--- a/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
+++ b/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
@@ -19,6 +19,8 @@ import org.talend.components.simplefileio.s3.output.S3OutputProperties;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
@@ -34,24 +36,22 @@ public class S3Connection {
         com.amazonaws.auth.AWSCredentials credentials = new com.amazonaws.auth.BasicAWSCredentials(
                 data_store.accessKey.getValue(), data_store.secretKey.getValue());
 
+        Region region = RegionUtils.getRegion(data_set.region.getValue().getValue());
         Boolean clientSideEnc = data_set.encryptDataInMotion.getValue();
 
         AmazonS3 conn = null;
         if (clientSideEnc != null && clientSideEnc) {
             String kms_cmk = data_set.kmsForDataInMotion.getValue();
             KMSEncryptionMaterialsProvider encryptionMaterialsProvider = new KMSEncryptionMaterialsProvider(kms_cmk);
-            
-            //TODO check if region is necessry for AWS KMS service here, now the code below is not called
-            //Region region = RegionUtils.getRegion(data_set.region.getValue().getValue());
             conn = new AmazonS3EncryptionClient(credentials, encryptionMaterialsProvider,
-                    new CryptoConfiguration()/*.withAwsKmsRegion(region)*/);
+                    new CryptoConfiguration().withAwsKmsRegion(region));
         } else {
             AWSCredentialsProvider basicCredentialsProvider = new StaticCredentialsProvider(credentials);
             conn = new AmazonS3Client(basicCredentialsProvider);
         }
 
-        //seems the region is only useful for creating bucket, not necessary for our usage, so remove it
-        //region.setRegion(region);
+        conn.setRegion(region);
+
         return conn;
     }
 

--- a/components/components-fileio/s3-runtime-di/src/test/java/org/talend/components/s3/runtime/PropertiesPreparer.java
+++ b/components/components-fileio/s3-runtime-di/src/test/java/org/talend/components/s3/runtime/PropertiesPreparer.java
@@ -5,7 +5,6 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.SchemaBuilder.FieldAssembler;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
-import org.talend.components.simplefileio.s3.S3Region;
 import org.talend.components.simplefileio.s3.output.S3OutputProperties;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
@@ -15,8 +14,6 @@ public class PropertiesPreparer {
     public static String accessKey = System.getProperty("s3.accesskey");
 
     public static String secretkey = System.getProperty("s3.secretkey");
-
-    public static String region = System.getProperty("s3.region");
 
     public static String bucket = System.getProperty("s3.bucket");
 
@@ -36,7 +33,6 @@ public class PropertiesPreparer {
 
         datastore.accessKey.setValue(accessKey);
         datastore.secretKey.setValue(secretkey);
-        dataset.region.setValue(S3Region.valueOf(region));
         dataset.bucket.setValue(bucket);
         dataset.kmsForDataInMotion.setValue(ssekmskey);
         dataset.kmsForDataAtRest.setValue(csekmskey);

--- a/components/components-fileio/s3-runtime-di/src/test/java/org/talend/components/s3/runtime/PropertiesPreparer.java
+++ b/components/components-fileio/s3-runtime-di/src/test/java/org/talend/components/s3/runtime/PropertiesPreparer.java
@@ -5,6 +5,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.SchemaBuilder.FieldAssembler;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
+import org.talend.components.simplefileio.s3.S3Region;
 import org.talend.components.simplefileio.s3.output.S3OutputProperties;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
@@ -14,6 +15,8 @@ public class PropertiesPreparer {
     public static String accessKey = System.getProperty("s3.accesskey");
 
     public static String secretkey = System.getProperty("s3.secretkey");
+
+    public static String region = System.getProperty("s3.region");
 
     public static String bucket = System.getProperty("s3.bucket");
 
@@ -33,6 +36,7 @@ public class PropertiesPreparer {
 
         datastore.accessKey.setValue(accessKey);
         datastore.secretKey.setValue(secretkey);
+        dataset.region.setValue(S3Region.valueOf(region));
         dataset.bucket.setValue(bucket);
         dataset.kmsForDataInMotion.setValue(ssekmskey);
         dataset.kmsForDataAtRest.setValue(csekmskey);

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -147,6 +147,10 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
     }
 
     public void afterDatastoreRef() {
+        //the current method is called at some strange place, need to skip it if bucket list have been set
+        if(!this.bucket.getPossibleValues().isEmpty()) {
+            return;
+        }
         S3DatasetDefinition definition = new S3DatasetDefinition();
         RuntimeInfo runtimeInfo = definition.getRuntimeInfo(this);
         try (SandboxedInstance sandboxedInstance = RuntimeUtil.createRuntimeClass(runtimeInfo, getClass().getClassLoader())) {

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -38,10 +38,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
             S3DatastoreDefinition.NAME);
 
     // S3 Connectivity
-    public Property<S3Region> region = PropertyFactory.newEnum("region", S3Region.class).setValue(S3Region.DEFAULT).setRequired();
-
-    public Property<String> unknownRegion = PropertyFactory.newString("unknownRegion", "us-east-1").setRequired();
-
     public Property<String> bucket = PropertyFactory.newString("bucket").setRequired();
 
     public Property<String> object = PropertyFactory.newString("object").setRequired();
@@ -95,8 +91,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         super.setupLayout();
         Form mainForm = new Form(this, Form.MAIN);
         // S3
-        mainForm.addRow(region);
-        mainForm.addRow(unknownRegion);
         mainForm.addRow(Widget.widget(bucket).setWidgetType(Widget.DATALIST_WIDGET_TYPE));
         mainForm.addRow(object);
         if (ACTIVATE_DATA_IN_MOTION) {
@@ -120,9 +114,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         // Main properties
         if (form.getName().equals(Form.MAIN)) {
             // S3
-            form.getWidget(region.getName()).setVisible();
-            form.getWidget(unknownRegion.getName()).setVisible(S3Region.OTHER.equals(region.getValue()));
-
             form.getWidget(bucket.getName()).setVisible();
             form.getWidget(object.getName()).setVisible();
             if (ACTIVATE_DATA_IN_MOTION) {
@@ -160,14 +151,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         }
     }
     
-    public void afterRegion() {
-        refreshLayout(getForm(Form.MAIN));
-    }
-
-    public void afterUnknownRegion() {
-        afterRegion();
-    }
-
     public void afterEncryptDataInMotion() {
         refreshLayout(getForm(Form.MAIN));
     }

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -32,8 +32,13 @@ import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.runtime.RuntimeUtil;
 import org.talend.daikon.sandbox.SandboxedInstance;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3DatasetProperties extends PropertiesImpl implements DatasetProperties<S3DatastoreProperties> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3DatasetProperties.class);
+  
     public final transient ReferenceProperties<S3DatastoreProperties> datastoreRef = new ReferenceProperties<>("datastoreRef",
             S3DatastoreDefinition.NAME);
 
@@ -78,6 +83,8 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
     @Override
     public void setDatastoreProperties(S3DatastoreProperties datastoreProperties) {
         datastoreRef.setReference(datastoreProperties);
+        //TODO should not call here, any reason? now it's necessary, if not, the trigger method don't work.
+        afterDatastoreRef();
     }
 
     @Override
@@ -147,7 +154,10 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
             runtime.initialize(null, this);
             this.bucket.setPossibleValues(new ArrayList<String>(runtime.listBuckets()));
         } catch (Exception e) {
-            TalendRuntimeException.build(ComponentsErrorCode.IO_EXCEPTION, e).throwIt();
+            //TalendRuntimeException.build(ComponentsErrorCode.IO_EXCEPTION, e).throwIt();
+            //ignore the exception here, as the trigger method should not block to save the data set properties action. 
+            //And as the current after data store trigger method is called at some strange place, the exception should not break something.
+            LOGGER.warn(e.getClass() + " : " + e.getMessage());
         }
     }
     

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -13,24 +13,16 @@
 
 package org.talend.components.simplefileio.s3;
 
-import java.util.ArrayList;
-
-import org.talend.components.api.exception.error.ComponentsErrorCode;
 import org.talend.components.common.dataset.DatasetProperties;
 import org.talend.components.simplefileio.SimpleFileIODatasetProperties.FieldDelimiterType;
 import org.talend.components.simplefileio.SimpleFileIODatasetProperties.RecordDelimiterType;
 import org.talend.components.simplefileio.SimpleFileIOFormat;
-import org.talend.components.simplefileio.s3.runtime.IS3DatasetRuntime;
-import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.properties.PropertiesImpl;
 import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
-import org.talend.daikon.runtime.RuntimeInfo;
-import org.talend.daikon.runtime.RuntimeUtil;
-import org.talend.daikon.sandbox.SandboxedInstance;
 
 public class S3DatasetProperties extends PropertiesImpl implements DatasetProperties<S3DatastoreProperties> {
 
@@ -38,10 +30,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
             S3DatastoreDefinition.NAME);
 
     // S3 Connectivity
-    public Property<S3Region> region = PropertyFactory.newEnum("region", S3Region.class).setValue(S3Region.DEFAULT).setRequired();
-
-    public Property<String> unknownRegion = PropertyFactory.newString("unknownRegion", "us-east-1").setRequired();
-
     public Property<String> bucket = PropertyFactory.newString("bucket").setRequired();
 
     public Property<String> object = PropertyFactory.newString("object").setRequired();
@@ -95,8 +83,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         super.setupLayout();
         Form mainForm = new Form(this, Form.MAIN);
         // S3
-        mainForm.addRow(region);
-        mainForm.addRow(unknownRegion);
         mainForm.addRow(Widget.widget(bucket).setWidgetType(Widget.DATALIST_WIDGET_TYPE));
         mainForm.addRow(object);
         if (ACTIVATE_DATA_IN_MOTION) {
@@ -120,9 +106,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         // Main properties
         if (form.getName().equals(Form.MAIN)) {
             // S3
-            form.getWidget(region.getName()).setVisible();
-            form.getWidget(unknownRegion.getName()).setVisible(S3Region.OTHER.equals(region.getValue()));
-
             form.getWidget(bucket.getName()).setVisible();
             form.getWidget(object.getName()).setVisible();
             if (ACTIVATE_DATA_IN_MOTION) {
@@ -146,23 +129,6 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
             form.getWidget(specificFieldDelimiter)
                     .setVisible(isCSV && fieldDelimiter.getValue().equals(FieldDelimiterType.OTHER));
         }
-    }
-
-    public void afterRegion() {
-        refreshLayout(getForm(Form.MAIN));
-        S3DatasetDefinition definition = new S3DatasetDefinition();
-        RuntimeInfo runtimeInfo = definition.getRuntimeInfo(this);
-        try (SandboxedInstance sandboxedInstance = RuntimeUtil.createRuntimeClass(runtimeInfo, getClass().getClassLoader())) {
-            IS3DatasetRuntime runtime = (IS3DatasetRuntime) sandboxedInstance.getInstance();
-            runtime.initialize(null, this);
-            this.bucket.setPossibleValues(new ArrayList<String>(runtime.listBuckets()));
-        } catch (Exception e) {
-            TalendRuntimeException.build(ComponentsErrorCode.IO_EXCEPTION, e).throwIt();
-        }
-    }
-
-    public void afterUnknownRegion() {
-        afterRegion();
     }
 
     public void afterEncryptDataInMotion() {

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -148,8 +148,7 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         }
     }
 
-    public void afterRegion() {
-        refreshLayout(getForm(Form.MAIN));
+    public void afterDatastoreRef() {
         S3DatasetDefinition definition = new S3DatasetDefinition();
         RuntimeInfo runtimeInfo = definition.getRuntimeInfo(this);
         try (SandboxedInstance sandboxedInstance = RuntimeUtil.createRuntimeClass(runtimeInfo, getClass().getClassLoader())) {
@@ -159,6 +158,10 @@ public class S3DatasetProperties extends PropertiesImpl implements DatasetProper
         } catch (Exception e) {
             TalendRuntimeException.build(ComponentsErrorCode.IO_EXCEPTION, e).throwIt();
         }
+    }
+    
+    public void afterRegion() {
+        refreshLayout(getForm(Form.MAIN));
     }
 
     public void afterUnknownRegion() {

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3Region.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3Region.java
@@ -23,10 +23,15 @@ public enum S3Region {
     AP_SOUTHEAST_2("ap-southeast-2"),
     AP_NORTHEAST_1("ap-northeast-1"),
     AP_NORTHEAST_2("ap-northeast-2"),
+    //TODO need to create a new s3 account for this region, not the common account, ignore it now
+    //AP_NORTHEAST_3("ap-northeast-3"),
     // http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region
     CN_NORTH_1("cn-north-1"),
+    //this region's action is the same with cn-north-1
+    CN_NORTHWEST_1("cn-northwest-1"),
     EU_WEST_1("eu-west-1"),
     EU_WEST_2("eu-west-2"),
+    EU_WEST_3("eu-west-3"),
     EU_CENTRAL_1("eu-central-1"),
     // http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html
     GovCloud("us-gov-west-1"),
@@ -36,54 +41,12 @@ public enum S3Region {
     US_EAST_2("us-east-2"),
     US_WEST_1("us-west-1"),
     US_WEST_2("us-west-2"),
-    OTHER("us-east-1");
+    OTHER("other-region");
 
     private String value;
 
     private S3Region(String value) {
         this.value = value;
-    }
-
-    public static S3Region fromString(String region) {
-        for (S3Region s3Region : S3Region.values()) {
-            if (s3Region.value.equalsIgnoreCase(region)) {
-                return s3Region;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Refer to this table to know the mapping between region/location/endpoint
-     * http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-     *
-     */
-    public static S3Region fromLocation(String location) {
-        if (location.equals("US")) { // refer to BucketLocationUnmarshaller
-            return S3Region.US_EAST_1;
-        } else if (location.equals("EU")) {
-            return S3Region.EU_WEST_1;
-        } else {
-            return fromString(location); // do not need to convert
-        }
-    }
-
-    /**
-     * Refer to this table to know the mapping between region/location/endpoint
-     * http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-     *
-     * @return
-     */
-    public String toEndpoint() {
-        switch (this) {
-        case GovCloud:
-            return "s3-us-gov-west-1.amazonaws.com";
-        case CN_NORTH_1:
-            return "s3.cn-north-1.amazonaws.com.cn";
-        default:
-            // Do not need special logical for us-east-1 by using dualstack, and it support IPv6 & IPv4
-            return String.format("s3.dualstack.%s.amazonaws.com", value);
-        }
     }
 
     public String getValue() {

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3RegionUtil.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3RegionUtil.java
@@ -1,0 +1,45 @@
+package org.talend.components.simplefileio.s3;
+
+public class S3RegionUtil {
+
+  
+    /**
+     * Some region has special endpoint
+     * 
+     * @param region
+     * @return
+     */
+    public static String regionToEndpoint(String region) {
+        S3Region s3Region = fromString(region);
+        switch (s3Region) {
+            case GovCloud:
+                return "s3-us-gov-west-1.amazonaws.com";
+            case CN_NORTH_1:
+                return "s3.cn-north-1.amazonaws.com.cn";
+            case CN_NORTHWEST_1:
+              return "s3.cn-northwest-1.amazonaws.com.cn";
+            default:
+              return String.format("s3.dualstack.%s.amazonaws.com", region);
+        }
+    }
+    
+    private static S3Region fromString(String region) {
+        for (S3Region s3Region : S3Region.values()) {
+            if (s3Region.getValue().equalsIgnoreCase(region)) {
+                return s3Region;
+            }
+        }
+        return S3Region.OTHER;
+    }
+    
+    public static String getBucketRegionFromLocation(String bucketLocation) {
+        if ("US".equals(bucketLocation)) { // refer to BucketLocationUnmarshaller
+            return S3Region.US_EAST_1.getValue();
+        } else if ("EU".equals(bucketLocation)) {
+            return S3Region.EU_WEST_1.getValue();
+        } else {
+            return bucketLocation;
+        }
+    }
+    
+}

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
@@ -75,15 +75,13 @@ public class S3DatasetPropertiesTest {
 
         Form main = properties.getForm(Form.MAIN);
         assertThat(main, notNullValue());
-        assertThat(main.getWidgets(), hasSize(11));
+        assertThat(main.getWidgets(), hasSize(9));
 
         for (String field : ALL) {
             Widget w = main.getWidget(field);
             assertThat(w, notNullValue());
         }
 
-        assertThat(properties.region.isRequired(), is(true));
-        assertThat(properties.unknownRegion.isRequired(), is(true));
         assertThat(properties.bucket.isRequired(), is(true));
         assertThat(properties.object.isRequired(), is(true));
         assertThat(main.getWidget("bucket").getWidgetType(), is(Widget.DATALIST_WIDGET_TYPE));

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
@@ -82,8 +82,6 @@ public class S3DatasetPropertiesTest {
             assertThat(w, notNullValue());
         }
 
-        assertThat(properties.region.isRequired(), is(true));
-        assertThat(properties.unknownRegion.isRequired(), is(true));
         assertThat(properties.bucket.isRequired(), is(true));
         assertThat(properties.object.isRequired(), is(true));
         assertThat(main.getWidget("bucket").getWidgetType(), is(Widget.DATALIST_WIDGET_TYPE));

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
@@ -75,7 +75,7 @@ public class S3DatasetPropertiesTest {
 
         Form main = properties.getForm(Form.MAIN);
         assertThat(main, notNullValue());
-        assertThat(main.getWidgets(), hasSize(11));
+        assertThat(main.getWidgets(), hasSize(9));
 
         for (String field : ALL) {
             Widget w = main.getWidget(field);

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
@@ -75,13 +75,15 @@ public class S3DatasetPropertiesTest {
 
         Form main = properties.getForm(Form.MAIN);
         assertThat(main, notNullValue());
-        assertThat(main.getWidgets(), hasSize(9));
+        assertThat(main.getWidgets(), hasSize(11));
 
         for (String field : ALL) {
             Widget w = main.getWidget(field);
             assertThat(w, notNullValue());
         }
 
+        assertThat(properties.region.isRequired(), is(true));
+        assertThat(properties.unknownRegion.isRequired(), is(true));
         assertThat(properties.bucket.isRequired(), is(true));
         assertThat(properties.object.isRequired(), is(true));
         assertThat(main.getWidget("bucket").getWidgetType(), is(Widget.DATALIST_WIDGET_TYPE));

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -242,6 +242,7 @@
                     <systemPropertyVariables>
                         <s3.accesskey>${s3.accesskey}</s3.accesskey>
                         <s3.secretkey>${s3.secretkey}</s3.secretkey>
+                        <s3.region>${s3.region}</s3.region>
                         <s3.bucket>${s3.bucket}</s3.bucket>
                         <s3.ssekmskey>${s3.ssekmskey}</s3.ssekmskey>
                         <s3.csekmskey>${s3.csekmskey}</s3.csekmskey>

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -242,7 +242,6 @@
                     <systemPropertyVariables>
                         <s3.accesskey>${s3.accesskey}</s3.accesskey>
                         <s3.secretkey>${s3.secretkey}</s3.secretkey>
-                        <s3.region>${s3.region}</s3.region>
                         <s3.bucket>${s3.bucket}</s3.bucket>
                         <s3.ssekmskey>${s3.ssekmskey}</s3.ssekmskey>
                         <s3.csekmskey>${s3.csekmskey}</s3.csekmskey>

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
@@ -86,7 +86,7 @@ public class S3Connection {
         //TODO should set the region here :
         //conf.set(Constants.ENDPOINT, "my_endpoint_from_dataset_properties");
         //need to it?
-        //conf.set(Constants.ENDPOINT, "random");
+        //conf.set("fs.s3a.experimental.input.fadvise", "random");
       
         if (properties.encryptDataAtRest.getValue()) {
             conf.set(Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM, S3AEncryptionMethods.SSE_KMS.getMethod());

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
@@ -16,12 +16,15 @@ package org.talend.components.simplefileio.runtime.s3;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.talend.components.simplefileio.runtime.ExtraHadoopConfiguration;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
+import org.talend.components.simplefileio.s3.S3RegionUtil;
 
 import com.talend.shaded.com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.talend.shaded.com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
@@ -49,7 +52,8 @@ public class S3Connection {
         AmazonS3 conn = new AmazonS3Client(credentials);
         return conn;
     }
-
+    
+    //TODO only use for test, should move it to test package
     public static S3AFileSystem createFileSystem(S3DatasetProperties properties) throws IOException {
         Configuration config = new Configuration(true);
         ExtraHadoopConfiguration extraConfig = new ExtraHadoopConfiguration();
@@ -83,8 +87,8 @@ public class S3Connection {
     }
 
     public static void setS3Configuration(ExtraHadoopConfiguration conf, S3DatasetProperties properties) {
-        //TODO should set the region here :
-        //conf.set(Constants.ENDPOINT, "my_endpoint_from_dataset_properties");
+        String endpoint = getEndpoint(properties);
+        conf.set(Constants.ENDPOINT, endpoint);
         //need to it?
         //conf.set("fs.s3a.experimental.input.fadvise", "random");
       
@@ -98,5 +102,31 @@ public class S3Connection {
             conf.set("fs.s3a.client-side-encryption-key", properties.kmsForDataInMotion.getValue());
         }
         setS3Configuration(conf, properties.getDatastoreProperties());
+    }
+    
+    //get the correct endpoint
+    public static String getEndpoint(S3DatasetProperties properties) {
+        String bucket = properties.bucket.getValue();
+        S3DatastoreProperties datastore = properties.getDatastoreProperties();
+        AmazonS3 s3client = S3Connection.createClient(datastore);
+        String bucketLocation = null;
+        try { 
+            bucketLocation = s3client.getBucketLocation(bucket);
+        } catch(IllegalArgumentException e) {
+            //java.lang.IllegalArgumentException: Cannot create enum from eu-west-2 value!
+            String info = e.getMessage();
+            if(info == null || info.isEmpty()) {
+                throw e;
+            }
+            Pattern regex = Pattern.compile("[a-zA-Z]+-[a-zA-Z]+-[1-9]");
+            Matcher matcher = regex.matcher(info);
+            if(matcher.find()) {
+                bucketLocation = matcher.group(0);
+            } else {
+                throw e;
+            }
+        }
+        String region = S3RegionUtil.getBucketRegionFromLocation(bucketLocation);
+        return S3RegionUtil.regionToEndpoint(region);
     }
 }

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
@@ -83,6 +83,11 @@ public class S3Connection {
     }
 
     public static void setS3Configuration(ExtraHadoopConfiguration conf, S3DatasetProperties properties) {
+        //TODO should set the region here :
+        //conf.set(Constants.ENDPOINT, "my_endpoint_from_dataset_properties");
+        //need to it?
+        //conf.set(Constants.ENDPOINT, "random");
+      
         if (properties.encryptDataAtRest.getValue()) {
             conf.set(Constants.SERVER_SIDE_ENCRYPTION_ALGORITHM, S3AEncryptionMethods.SSE_KMS.getMethod());
             conf.set(Constants.SERVER_SIDE_ENCRYPTION_KEY, properties.kmsForDataAtRest.getValue());

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
@@ -25,11 +25,9 @@ import org.apache.beam.sdk.transforms.Sample;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.components.adapter.beam.BeamLocalRunnerOption;
-import org.talend.components.adapter.beam.coders.LazyAvroCoder;
 import org.talend.components.adapter.beam.transform.DirectConsumerCollector;
 import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
-import org.talend.components.simplefileio.s3.S3Region;
 import org.talend.components.simplefileio.s3.input.S3InputProperties;
 import org.talend.components.simplefileio.s3.runtime.IS3DatasetRuntime;
 import org.talend.daikon.java8.Consumer;
@@ -50,58 +48,12 @@ public class S3DatasetRuntime implements IS3DatasetRuntime {
     @Override
     public Set<String> listBuckets() {
         AmazonS3 conn = S3Connection.createClient(properties.getDatastoreProperties());
-        String region = properties.region.getValue().getValue();
-        if (S3Region.OTHER.getValue().equals(region)) {
-            region = properties.unknownRegion.getValue();
-        }
-        conn.setEndpoint(regionToEndpoint(region));
-        LOG.debug("Start to find buckets in region {}", region);
         List<Bucket> buckets = conn.listBuckets();
         Set<String> bucketsName = new HashSet<>();
         for (Bucket bucket : buckets) {
-            String bucketName = bucket.getName();
-            try {
-                String bucketLocation = conn.getBucketLocation(bucketName);
-                String bucketRegion = locationToRegion(bucketLocation);
-                LOG.debug("Bucket is {} and location is {}({})", bucketName, bucketLocation, bucketRegion);
-                if (region.equals(bucketRegion)) {
-                    bucketsName.add(bucketName);
-                }
-            } catch (Exception e) {
-                // Ignore any exception when calling getBucketLocation, try next
-                LOG.debug("Exception when check bucket location: {}", e.getMessage());
-            }
+            bucketsName.add(bucket.getName());
         }
         return bucketsName;
-    }
-
-    /**
-     * Some region has special endpoint
-     * 
-     * @param region
-     * @return
-     */
-    private String regionToEndpoint(String region) {
-        S3Region s3Region = S3Region.fromString(region);
-        if (s3Region != null) {
-            return s3Region.toEndpoint();
-        } else {
-            // TODO let the user provide endpoint,
-            // or we remove the custom region, and provide a configuration file can be loaded on fly, keep update
-            // also need to consider location to region mapping
-            return String.format("s3.dualstack.%s.amazonaws.com", region);
-        }
-    }
-
-    /**
-     * Some region has multiple locations
-     * 
-     * @param location
-     * @return
-     */
-    private String locationToRegion(String location) {
-        S3Region bucketRegion = S3Region.fromLocation(location);
-        return bucketRegion == null ? location : bucketRegion.getValue();
     }
 
     @Override

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
@@ -49,11 +49,6 @@ public class S3DatasetRuntime implements IS3DatasetRuntime {
     @Override
     public Set<String> listBuckets() {
         AmazonS3 conn = S3Connection.createClient(properties.getDatastoreProperties());
-        String region = properties.region.getValue().getValue();
-        if (S3Region.OTHER.getValue().equals(region)) {
-            region = properties.unknownRegion.getValue();
-        }
-        conn.setEndpoint(regionToEndpoint(region));
         LOG.debug("Start to find buckets");
         List<Bucket> buckets = conn.listBuckets();
         Set<String> bucketsName = new HashSet<>();
@@ -64,7 +59,7 @@ public class S3DatasetRuntime implements IS3DatasetRuntime {
     }
 
     /**
-     * Some region has special endpoint
+     * Some region has special endpoint, TODO it's useful for future, so keep it though not used now
      * 
      * @param region
      * @return

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
@@ -58,24 +58,6 @@ public class S3DatasetRuntime implements IS3DatasetRuntime {
         return bucketsName;
     }
 
-    /**
-     * Some region has special endpoint, TODO it's useful for future, so keep it though not used now
-     * 
-     * @param region
-     * @return
-     */
-    private String regionToEndpoint(String region) {
-        S3Region s3Region = S3Region.fromString(region);
-        if (s3Region != null) {
-            return s3Region.toEndpoint();
-        } else {
-            // TODO let the user provide endpoint,
-            // or we remove the custom region, and provide a configuration file can be loaded on fly, keep update
-            // also need to consider location to region mapping
-            return String.format("s3.dualstack.%s.amazonaws.com", region);
-        }
-    }
-
     @Override
     public Schema getSchema() {
         // Simple schema container.

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
@@ -28,7 +28,6 @@ import org.talend.components.adapter.beam.BeamLocalRunnerOption;
 import org.talend.components.adapter.beam.transform.DirectConsumerCollector;
 import org.talend.components.api.container.RuntimeContainer;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
-import org.talend.components.simplefileio.s3.S3Region;
 import org.talend.components.simplefileio.s3.input.S3InputProperties;
 import org.talend.components.simplefileio.s3.runtime.IS3DatasetRuntime;
 import org.talend.daikon.java8.Consumer;

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
@@ -22,12 +22,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3Region;
+import org.talend.components.simplefileio.s3.S3RegionUtil;
 
 import com.talend.shaded.com.amazonaws.services.s3.AmazonS3;
 
@@ -40,23 +41,20 @@ public class S3DatasetRuntimeTestIT {
     @Rule
     public S3TestResource s3 = S3TestResource.of();
 
-    S3DatasetRuntime runtime;
-
-    @Before
-    public void reset() {
-        runtime = new S3DatasetRuntime();
-    }
 
     @Test
     @Ignore("It's slow (10 or more mins), our account doesn't allow to create this amount of buckets")
+    //don't know why need to ignore it, at least, component team s3 account can pass the test, now performance is OK as we don't filter buckets by region now
     public void listBuckets() {
         String uuid = UUID.randomUUID().toString().substring(0, 8);
         String bucketFormat = "tcomp-s3-dataset-test-%s-" + uuid;
         S3DatasetProperties s3DatasetProperties = s3.createS3DatasetProperties();
+        S3DatasetRuntime runtime = new S3DatasetRuntime();
         runtime.initialize(null, s3DatasetProperties);
         AmazonS3 client = S3Connection.createClient(s3.createS3DatastoreProperties());
         for (S3Region s3Region : getTestableS3Regions()) {
-            client.setEndpoint(s3Region.toEndpoint());
+            String endpoint = S3RegionUtil.regionToEndpoint(s3Region.getValue());
+            client.setEndpoint(endpoint);
             if (s3Region.equals(S3Region.US_EAST_1)) {
                 client.createBucket(String.format(bucketFormat, s3Region.getValue()));
             } else {
@@ -68,7 +66,7 @@ public class S3DatasetRuntimeTestIT {
             assertTrue(bucketNames.size() > 0);
             assertThat(bucketNames, hasItems(String.format(bucketFormat, s3Region.getValue())));
 
-            client.setEndpoint(s3Region.toEndpoint());
+            client.setEndpoint(endpoint);
             client.deleteBucket(String.format(bucketFormat, s3Region.getValue()));
         }
     }
@@ -81,6 +79,7 @@ public class S3DatasetRuntimeTestIT {
             case OTHER:
             case GovCloud:
             case CN_NORTH_1:
+            case CN_NORTHWEST_1:
                 break;
             default:
                 testableRegions.add(s3Region);
@@ -88,6 +87,36 @@ public class S3DatasetRuntimeTestIT {
             }
         }
         return testableRegions;
+    }
+    
+    @Test
+    @Ignore("It's slow (10 or more mins), our account doesn't allow to create this amount of buckets")
+    //don't know why need to ignore it, at least, component team s3 account can pass the test
+    public void getBucketEndpoint() {
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        String bucketFormat = "tcomp-s3-dataset-test-%s-" + uuid;
+        S3DatasetProperties s3DatasetProperties = s3.createS3DatasetProperties();
+        AmazonS3 client = S3Connection.createClient(s3.createS3DatastoreProperties());
+        for (S3Region s3Region : getTestableS3Regions()) {
+            String endpoint = S3RegionUtil.regionToEndpoint(s3Region.getValue());
+            client.setEndpoint(endpoint);
+            
+            String bucketName = String.format(bucketFormat, s3Region.getValue());
+            if (s3Region.equals(S3Region.US_EAST_1)) {
+                client.createBucket(bucketName);
+            } else {
+                client.createBucket(bucketName, s3Region.getValue());
+            }
+
+            s3DatasetProperties.region.setValue(null);
+            s3DatasetProperties.bucket.setValue(bucketName);
+            String endpointFromBucket = S3Connection.getEndpoint(s3DatasetProperties);
+            
+            Assert.assertEquals(endpoint, endpointFromBucket);
+
+            client.setEndpoint(endpoint);
+            client.deleteBucket(bucketName);
+        }
     }
 
 }

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
@@ -63,7 +63,6 @@ public class S3DatasetRuntimeTestIT {
                 client.createBucket(String.format(bucketFormat, s3Region.getValue()), s3Region.getValue());
             }
 
-            s3DatasetProperties.region.setValue(s3Region);
             Set<String> bucketNames = runtime.listBuckets();
             assertTrue(bucketNames.size() > 0);
             assertThat(bucketNames, hasItems(String.format(bucketFormat, s3Region.getValue())));

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
@@ -61,7 +61,6 @@ public class S3DatasetRuntimeTestIT {
                 client.createBucket(String.format(bucketFormat, s3Region.getValue()), s3Region.getValue());
             }
 
-            s3DatasetProperties.region.setValue(s3Region);
             Set<String> bucketNames = runtime.listBuckets();
             assertTrue(bucketNames.size() > 0);
             assertThat(bucketNames, hasItems(String.format(bucketFormat, s3Region.getValue())));
@@ -108,7 +107,6 @@ public class S3DatasetRuntimeTestIT {
                 client.createBucket(bucketName, s3Region.getValue());
             }
 
-            s3DatasetProperties.region.setValue(null);
             s3DatasetProperties.bucket.setValue(bucketName);
             String endpointFromBucket = S3Connection.getEndpoint(s3DatasetProperties);
             

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
@@ -63,6 +63,7 @@ public class S3DatasetRuntimeTestIT {
                 client.createBucket(String.format(bucketFormat, s3Region.getValue()), s3Region.getValue());
             }
 
+            s3DatasetProperties.region.setValue(s3Region);
             Set<String> bucketNames = runtime.listBuckets();
             assertTrue(bucketNames.size() > 0);
             assertThat(bucketNames, hasItems(String.format(bucketFormat, s3Region.getValue())));

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntimeTestIT.java
@@ -3,6 +3,7 @@ package org.talend.components.simplefileio.runtime.s3;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
@@ -25,6 +26,7 @@ public class S3DatastoreRuntimeTestIT {
     }
 
     @Test
+    @Ignore("It fails. Should be fixed")
     public void doHealthChecksTest_s3() {
         runtime.initialize(null, s3.createS3DatastoreProperties());
         Iterable<ValidationResult> validationResults = runtime.doHealthChecks(null);

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntimeTestIT.java
@@ -3,7 +3,6 @@ package org.talend.components.simplefileio.runtime.s3;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
@@ -26,7 +25,6 @@ public class S3DatastoreRuntimeTestIT {
     }
 
     @Test
-    @Ignore("It fails. Should be fixed")
     public void doHealthChecksTest_s3() {
         runtime.initialize(null, s3.createS3DatastoreProperties());
         Iterable<ValidationResult> validationResults = runtime.doHealthChecks(null);

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
@@ -27,7 +27,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
-import org.talend.components.simplefileio.s3.S3Region;
 
 import com.talend.shaded.com.amazonaws.services.s3.model.ObjectMetadata;
 import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
@@ -41,7 +40,6 @@ import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
  *   <properties>
  *     <s3.accesskey>ACCESS_KEY</s3.accesskey>
  *     <s3.secretkey>SECRETY_KEY</s3.secretkey>
- *     <s3.region>EU_WEST_1</s3.region>
  *     <s3.bucket>testbucket</s3.bucket>
  *     <s3.ssekmskey>KEY1</s3.ssekmskey>
  *     <s3.csekmskey>KEY2</s3.csekmskey>
@@ -94,7 +92,7 @@ public class S3TestResource extends ExternalResource {
     }
 
     /**
-     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The region are
+     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The 
      * bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties() {
@@ -107,12 +105,11 @@ public class S3TestResource extends ExternalResource {
      * @param sseKms Whether server-side encryption is used. The KMS key is taken from the system environment.
      * @param sseKms Whether client-side encryption is used. The KMS key is taken from the system environment.
      * @return An S3DatasetProperties with credentials in the datastore, configured for the specified encryption. The
-     * region are bucket are taken from the environment, and a unique "object" property is created for this unit test.
+     * bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties(boolean sseKms, boolean cseKms) {
         S3DatasetProperties properties = new S3DatasetProperties(null);
         properties.init();
-        properties.region.setValue(S3Region.valueOf(System.getProperty("s3.region")));
         properties.bucket.setValue(bucketName);
         properties.object.setValue(getPath());
         properties.setDatastoreProperties(createS3DatastoreProperties());

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
@@ -40,7 +40,6 @@ import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
  *   <properties>
  *     <s3.accesskey>ACCESS_KEY</s3.accesskey>
  *     <s3.secretkey>SECRETY_KEY</s3.secretkey>
- *     <s3.region>EU_WEST_1</s3.region>
  *     <s3.bucket>testbucket</s3.bucket>
  *     <s3.ssekmskey>KEY1</s3.ssekmskey>
  *     <s3.csekmskey>KEY2</s3.csekmskey>
@@ -93,7 +92,7 @@ public class S3TestResource extends ExternalResource {
     }
 
     /**
-     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The region are
+     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The 
      * bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties() {
@@ -105,8 +104,8 @@ public class S3TestResource extends ExternalResource {
      * 
      * @param sseKms Whether server-side encryption is used. The KMS key is taken from the system environment.
      * @param sseKms Whether client-side encryption is used. The KMS key is taken from the system environment.
-     * @return An S3DatasetProperties with credentials in the datastore, configured for the specified encryption. The
-     * region are bucket are taken from the environment, and a unique "object" property is created for this unit test.
+     * @return An S3DatasetProperties with credentials in the datastore, configured for the specified encryption. The 
+     * bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties(boolean sseKms, boolean cseKms) {
         S3DatasetProperties properties = new S3DatasetProperties(null);

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
@@ -27,7 +27,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
-import org.talend.components.simplefileio.s3.S3Region;
 
 import com.talend.shaded.com.amazonaws.services.s3.model.ObjectMetadata;
 import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
@@ -112,7 +111,6 @@ public class S3TestResource extends ExternalResource {
     public S3DatasetProperties createS3DatasetProperties(boolean sseKms, boolean cseKms) {
         S3DatasetProperties properties = new S3DatasetProperties(null);
         properties.init();
-        properties.region.setValue(S3Region.valueOf(System.getProperty("s3.region")));
         properties.bucket.setValue(bucketName);
         properties.object.setValue(getPath());
         properties.setDatastoreProperties(createS3DatastoreProperties());

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
@@ -27,6 +27,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.talend.components.simplefileio.s3.S3DatasetProperties;
 import org.talend.components.simplefileio.s3.S3DatastoreProperties;
+import org.talend.components.simplefileio.s3.S3Region;
 
 import com.talend.shaded.com.amazonaws.services.s3.model.ObjectMetadata;
 import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
@@ -40,6 +41,7 @@ import com.talend.shaded.org.apache.hadoop.fs.s3a.S3AFileSystem;
  *   <properties>
  *     <s3.accesskey>ACCESS_KEY</s3.accesskey>
  *     <s3.secretkey>SECRETY_KEY</s3.secretkey>
+ *     <s3.region>EU_WEST_1</s3.region>
  *     <s3.bucket>testbucket</s3.bucket>
  *     <s3.ssekmskey>KEY1</s3.ssekmskey>
  *     <s3.csekmskey>KEY2</s3.csekmskey>
@@ -92,7 +94,7 @@ public class S3TestResource extends ExternalResource {
     }
 
     /**
-     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The 
+     * @return An S3DatasetProperties with credentials in the datastore, not configured for encryption. The region are
      * bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties() {
@@ -104,12 +106,13 @@ public class S3TestResource extends ExternalResource {
      * 
      * @param sseKms Whether server-side encryption is used. The KMS key is taken from the system environment.
      * @param sseKms Whether client-side encryption is used. The KMS key is taken from the system environment.
-     * @return An S3DatasetProperties with credentials in the datastore, configured for the specified encryption. The 
-     * bucket are taken from the environment, and a unique "object" property is created for this unit test.
+     * @return An S3DatasetProperties with credentials in the datastore, configured for the specified encryption. The
+     * region are bucket are taken from the environment, and a unique "object" property is created for this unit test.
      */
     public S3DatasetProperties createS3DatasetProperties(boolean sseKms, boolean cseKms) {
         S3DatasetProperties properties = new S3DatasetProperties(null);
         properties.init();
+        properties.region.setValue(S3Region.valueOf(System.getProperty("s3.region")));
         properties.bucket.setValue(bucketName);
         properties.object.setValue(getPath());
         properties.setDatastoreProperties(createS3DatastoreProperties());


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40107


**What is the new behavior?**
https://jira.talendforge.org/browse/TDI-40107


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No