### PR TITLE
fix(TFD-3920) : use supplied avro schema in kafka dataset

### DIFF
--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
@@ -12,18 +12,17 @@
 // ============================================================================
 package org.talend.components.kafka.runtime;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.Charset;
-
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.WithKeys;
@@ -40,6 +39,11 @@ import org.talend.components.kafka.output.KafkaOutputProperties;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.properties.ValidationResult;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+
 public class KafkaOutputPTransformRuntime extends PTransform<PCollection<IndexedRecord>, PDone>
         implements RuntimableRuntime<KafkaOutputProperties> {
 
@@ -51,6 +55,9 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
     public PDone expand(PCollection<IndexedRecord> objectPCollection) {
         final boolean useAvro =
                 properties.getDatasetProperties().valueFormat.getValue() == KafkaDatasetProperties.ValueFormat.AVRO;
+        final String kafkaDatasetStringSchema = properties.getDatasetProperties().avroSchema.getValue();
+        final boolean useCustomAvroSchema = properties.getDatasetProperties().isHierarchy.getValue();
+        final IndexedRecordHelper indexedRecordHelper = new IndexedRecordHelper(kafkaDatasetStringSchema, useCustomAvroSchema);
 
         KafkaIO.Write<byte[], byte[]> kafkaWrite = KafkaIO
                 .<byte[], byte[]> write()
@@ -65,7 +72,7 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
             PCollection pc1 = objectPCollection.apply(WithKeys.of(new ProduceKey(properties.keyColumn.getValue())));
             if (useAvro) {
                 // TODO for now use incoming avro schema directly, do not check configured schema, improvement it.
-                return ((PCollection<KV<byte[], byte[]>>) pc1.apply(MapElements.via(new AvroToByteArrayKV())))
+                return ((PCollection<KV<byte[], byte[]>>) pc1.apply(ParDo.of(new AvroKVToByteArrayDoFn(indexedRecordHelper))))
                         .apply(kafkaWrite);
             } else { // csv
                 return ((PCollection<KV<byte[], byte[]>>) pc1.apply(
@@ -76,7 +83,7 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
         case ROUND_ROBIN: {
             if (useAvro) {
                 // TODO for now use incoming avro schema directly, do not check configured schema, improvement it.
-                return (PDone) objectPCollection.apply(MapElements.via(new AvroToByteArray())).apply(
+                return (PDone) objectPCollection.apply(ParDo.of(new AvroToByteArrayDoFn(indexedRecordHelper))).apply(
                         kafkaWrite.values());
             } else { // csv
                 return (PDone) objectPCollection
@@ -94,37 +101,6 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
     public ValidationResult initialize(RuntimeContainer container, KafkaOutputProperties properties) {
         this.properties = properties;
         return ValidationResult.OK;
-    }
-
-    public static class AvroToByteArrayKV extends SimpleFunction<KV<byte[], IndexedRecord>, KV<byte[], byte[]>> {
-
-        private AvroToByteArray converter = new AvroToByteArray();
-
-        @Override
-        public KV<byte[], byte[]> apply(KV<byte[], IndexedRecord> input) {
-            return KV.of(input.getKey(), converter.apply(input.getValue()));
-        }
-
-    }
-
-    public static class AvroToByteArray extends SimpleFunction<IndexedRecord, byte[]> {
-
-        @Override
-        public byte[] apply(IndexedRecord input) {
-            try {
-                DatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter(input.getSchema());
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
-                datumWriter.write(input, encoder);
-                encoder.flush();
-                byte[] result = out.toByteArray();
-                out.close();
-                return result;
-            } catch (IOException e) {
-                throw TalendRuntimeException.createUnexpectedException(e);
-            }
-        }
-
     }
 
     public static class FormatCsvKV extends SimpleFunction<KV<byte[], IndexedRecord>, KV<byte[], byte[]>> {
@@ -191,6 +167,189 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
         public byte[] apply(IndexedRecord input) {
             Object k = input.get(input.getSchema().getField(keyName).pos());
             return String.valueOf(k).getBytes(Charset.forName("UTF-8"));
+        }
+    }
+
+    /**
+     * An {@link IndexedRecord} wrapper to wrap {@link IndexedRecord} with a custom
+     * Kafka Avro schema. Calls are delegated to the wrapped {@link IndexedRecord},
+     * with the exception of @getSchema that returns a fixed {@link Schema}
+     */
+    public static class KafkaIndexedRecordWrapper implements IndexedRecord {
+
+        IndexedRecord incomingIndexedRecord;
+        Schema datasetSchema;
+
+        public void setIndexedRecord(IndexedRecord incomingIndexedRecord){
+            this.incomingIndexedRecord = incomingIndexedRecord;
+        }
+
+        public void setDatasetSchema(Schema datasetSchema){
+            this.datasetSchema = datasetSchema;
+        }
+
+        @Override
+        public void put(int i, Object v) {
+            incomingIndexedRecord.put(i, v);
+        }
+
+        @Override
+        public Object get(int i) {
+            return incomingIndexedRecord.get(i);
+        }
+
+        @Override
+        public Schema getSchema() {
+            return datasetSchema;
+        }
+    }
+
+    /**
+     * Transform Avro {@link IndexedRecord} into a byte array.
+     *
+     * In case of a dataset that uses a custom avro schema, the @processElement method
+     * uses the {@link IndexedRecordHelper} to wrap incoming records in
+     * {@link KafkaIndexedRecordWrapper} and then writes them using the custom Avro schema.
+     * Otherwise, the incoming records are written with their original schema.
+     */
+    public static class AvroKVToByteArrayDoFn extends DoFn<KV<byte[], IndexedRecord>, KV<byte[], byte[]>> {
+
+        IndexedRecordHelper helper;
+
+        AvroKVToByteArrayDoFn(IndexedRecordHelper helper){
+            this.helper = helper;
+        }
+
+        @Setup
+        public void setup() {
+            helper.setup();
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            try {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+                if(helper.isUseCustomAvroSchema()){
+                    helper.getKafkaIndexedRecordWrapper().setIndexedRecord(c.element().getValue());
+                    helper.getDatumWriter().write(helper.getKafkaIndexedRecordWrapper(), encoder);
+                } else {
+                    if(helper.getDatumWriter() == null){
+                        // set the datumWriter for the first time with the incoming record schema
+                        helper.setDatumWriter(new GenericDatumWriter(c.element().getValue().getSchema()));
+                    }
+                    helper.getDatumWriter().write(c.element().getValue(), encoder);
+                }
+                encoder.flush();
+                byte[] result = out.toByteArray();
+                out.close();
+                c.output(KV.of(c.element().getKey(), result));
+            } catch (IOException e) {
+                throw TalendRuntimeException.createUnexpectedException(e);
+            }
+        }
+    }
+
+    /**
+     * Transform Avro {@link IndexedRecord} into a byte array.
+     *
+     * In case of a dataset that uses a custom avro schema, the @processElement method
+     * uses the {@link IndexedRecordHelper} to wrap incoming records in
+     * {@link KafkaIndexedRecordWrapper} and then writes them using the custom Avro schema.
+     * Otherwise, the incoming records are written with their original schema.
+     */
+    public static class AvroToByteArrayDoFn extends DoFn<IndexedRecord, byte[]> {
+
+        IndexedRecordHelper helper;
+
+        AvroToByteArrayDoFn(IndexedRecordHelper helper){
+            this.helper = helper;
+        }
+
+        @Setup
+        public void setup() {
+            LOG.error(helper.toString());
+            helper.setup();
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            try {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+                if(helper.isUseCustomAvroSchema()){
+                    helper.getKafkaIndexedRecordWrapper().setIndexedRecord(c.element());
+                    helper.getDatumWriter().write(helper.getKafkaIndexedRecordWrapper(), encoder);
+                } else {
+                    if(helper.getDatumWriter() == null){
+                        LOG.error(c.element().getSchema().toString(true));
+                        // set the datumWriter for the first time with the incoming record schema
+                        helper.setDatumWriter(new GenericDatumWriter(c.element().getSchema()));
+                    }
+                    helper.getDatumWriter().write(c.element(), encoder);
+                }
+                encoder.flush();
+                byte[] result = out.toByteArray();
+                out.close();
+                c.output(result);
+            } catch (IOException e) {
+                throw TalendRuntimeException.createUnexpectedException(e);
+            }
+        }
+    }
+
+    /**
+     * {@link IndexedRecord} helper to setup {@link DoFn} classes for working with incoming records
+     * {@link IndexedRecord} to Byte arrays and avoid object instantiation inside @{@link org.apache.beam.sdk.transforms.DoFn.ProcessElement}
+     *
+     * If @useCustomAvroSchema is set to true, we initialize some helper objects in the @setup().
+     */
+    public static class IndexedRecordHelper implements Serializable {
+
+        private String kafkaDatasetStringSchema;
+        private boolean useCustomAvroSchema;
+        private KafkaIndexedRecordWrapper kafkaIndexedRecordWrapper;
+        private DatumWriter<IndexedRecord> datumWriter;
+
+        IndexedRecordHelper(String kafkaDatasetStringSchema, boolean useCustomAvroSchema){
+            this.useCustomAvroSchema = useCustomAvroSchema;
+            this.kafkaDatasetStringSchema = kafkaDatasetStringSchema;
+        }
+
+        public void setup(){
+            if(useCustomAvroSchema){
+                kafkaIndexedRecordWrapper = new KafkaIndexedRecordWrapper();
+                org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+                Schema kafkaDatasetSchema = parser.parse(kafkaDatasetStringSchema);
+                kafkaIndexedRecordWrapper.setDatasetSchema(kafkaDatasetSchema);
+                datumWriter = new GenericDatumWriter(kafkaDatasetSchema);
+            }
+        }
+
+        public KafkaIndexedRecordWrapper getKafkaIndexedRecordWrapper() {
+            return kafkaIndexedRecordWrapper;
+        }
+
+        public DatumWriter<IndexedRecord> getDatumWriter() {
+            return datumWriter;
+        }
+
+        public boolean isUseCustomAvroSchema() {
+            return useCustomAvroSchema;
+        }
+
+        public void setDatumWriter(DatumWriter<IndexedRecord> datumWriter) {
+            this.datumWriter = datumWriter;
+        }
+
+        @Override
+        public String toString() {
+            return "IndexedRecordHelper{" +
+                    "kafkaDatasetStringSchema='" + kafkaDatasetStringSchema + '\'' +
+                    ", useCustomAvroSchema=" + useCustomAvroSchema +
+                    ", kafkaIndexedRecordWrapper=" + kafkaIndexedRecordWrapper +
+                    ", datumWriter=" + datumWriter +
+                    '}';
         }
     }
 }

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
@@ -205,9 +205,9 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
     }
 
     /**
-     * Transform Avro {@link IndexedRecord} into a byte array.
+     * Transform Avro key value {@link IndexedRecord} into a byte array.
      *
-     * In case of a dataset that uses a custom avro schema, the @processElement method
+     * In case of a dataset that uses a custom Avro schema, the @processElement method
      * uses the {@link IndexedRecordHelper} to wrap incoming records in
      * {@link KafkaIndexedRecordWrapper} and then writes them using the custom Avro schema.
      * Otherwise, the incoming records are written with their original schema.
@@ -253,7 +253,7 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
     /**
      * Transform Avro {@link IndexedRecord} into a byte array.
      *
-     * In case of a dataset that uses a custom avro schema, the @processElement method
+     * In case of a dataset that uses a custom Avro schema, the @processElement method
      * uses the {@link IndexedRecordHelper} to wrap incoming records in
      * {@link KafkaIndexedRecordWrapper} and then writes them using the custom Avro schema.
      * Otherwise, the incoming records are written with their original schema.
@@ -268,7 +268,6 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
 
         @Setup
         public void setup() {
-            LOG.error(helper.toString());
             helper.setup();
         }
 
@@ -282,7 +281,6 @@ public class KafkaOutputPTransformRuntime extends PTransform<PCollection<Indexed
                     helper.getDatumWriter().write(helper.getKafkaIndexedRecordWrapper(), encoder);
                 } else {
                     if(helper.getDatumWriter() == null){
-                        LOG.error(c.element().getSchema().toString(true));
                         // set the datumWriter for the first time with the incoming record schema
                         helper.setDatumWriter(new GenericDatumWriter(c.element().getSchema()));
                     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Kafka output dataset avro schema is inferred from the incoming data, and the dataset's user defined avro schema is not used. 

**What is the new behavior?**
Use user supplied schema as output schema for kafak output avro dataset.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
