### PR TITLE
fix(rskraba): Don't write files for empty streaming panes.

### DIFF
--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/ConfigurableHDFSFileSink.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/ConfigurableHDFSFileSink.java
@@ -327,6 +327,10 @@ public class ConfigurableHDFSFileSink<K, V> extends Sink<KV<K, V>> {
          * normal operations, but is necessary for TFD-3404 for now.
          */
         public void commitManually(String committed, String rewriteFile) throws IOException {
+            // If the writer was never opened for writing records, then there's nothing to commit.
+            if (outputCommitter == null)
+                return;
+
             Path srcDir = outputCommitter.getCommittedTaskPath(context);
             Path src = new Path(srcDir, committed);
             Path dst = new Path(path, rewriteFile);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

When writing a Streaming pane to a file, a NPE can occur if there are no records in the pane.

**What is the new behavior?**

When writing a Streaming pane to a file, panes without records are silently ignored.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
