### PR TITLE
fix(TDI-37641): add ID field for Update and Delete actions

### DIFF
--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -36,7 +36,7 @@ public class TSalesforceOutputDefinition extends SalesforceDefinition {
 
     @Override
     public boolean isSchemaAutoPropagate() {
-        return false;
+        return true;
     }
 
     @Override

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -18,18 +18,25 @@ import static org.talend.daikon.properties.property.PropertyFactory.newInteger;
 import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
 import org.talend.components.api.component.ISchemaListener;
 import org.talend.components.salesforce.SalesforceOutputProperties;
+import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 
 public class TSalesforceOutputProperties extends SalesforceOutputProperties {
+
+    public static final String SALESFORCE_ID = "Id";
+
+    private static final String SALESFORCE_ID_LENGTH = "18";
 
     public static final String FIELD_SALESFORCE_ID = "salesforce_id";
 
@@ -84,7 +91,7 @@ public class TSalesforceOutputProperties extends SalesforceOutputProperties {
 
         if (!extendInsert.getValue() && retrieveInsertId.getValue()
                 && (OutputAction.INSERT.equals(outputAction.getValue()) || OutputAction.UPSERT.equals(outputAction.getValue()))) {
-            final List<Schema.Field> additionalMainFields = new ArrayList<Schema.Field>();
+            final List<Schema.Field> additionalMainFields = cloneFields(inputSchema);
 
             field = new Schema.Field(FIELD_SALESFORCE_ID, Schema.create(Schema.Type.STRING), null, (Object) null);
             field.addProp(SchemaConstants.TALEND_IS_LOCKED, "false");
@@ -98,13 +105,31 @@ public class TSalesforceOutputProperties extends SalesforceOutputProperties {
                 field.addProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255");
                 additionalMainFields.add(field);
             }
-            Schema mainOutputSchema = newSchema(inputSchema, "output", additionalMainFields);
-            schemaFlow.schema.setValue(mainOutputSchema);
+            schemaFlow.schema.setValue(newSchema(inputSchema, "output", additionalMainFields));
+        } else if (OutputAction.UPDATE == outputAction.getValue()
+                && inputSchema.getField(SALESFORCE_ID) == null
+                && !AvroUtils.isIncludeAllFields(inputSchema)){
+            field = new Schema.Field(SALESFORCE_ID, Schema.create(Schema.Type.STRING), null, (Object) null);
+            field.addProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH, SALESFORCE_ID_LENGTH);
+            field.addProp(SchemaConstants.TALEND_IS_LOCKED, "true");
+            List<Field> clonedFields = cloneFields(inputSchema);
+            clonedFields.add(0, field);
+            Schema updateSchema = newSchema(inputSchema, "output", clonedFields);
+            module.main.schema.setValue(updateSchema);
+            schemaFlow.schema.setValue(updateSchema);
+        } else if (OutputAction.DELETE == outputAction.getValue()) {
+            field = new Schema.Field(SALESFORCE_ID, Schema.create(Schema.Type.STRING), null, (Object) null);
+            field.addProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH, SALESFORCE_ID_LENGTH);
+            field.addProp(SchemaConstants.TALEND_IS_LOCKED, "true");
+            Schema deleteSchema = Schema.createRecord("DeleteSchema", null, null, false, Collections.singletonList(field));
+            deleteSchema.addProp(SchemaConstants.TALEND_IS_LOCKED, "true");
+            module.main.schema.setValue(deleteSchema);
+            schemaFlow.schema.setValue(deleteSchema);
         } else {
             schemaFlow.schema.setValue(inputSchema);
         }
 
-        final List<Schema.Field> additionalRejectFields = new ArrayList<Schema.Field>();
+        final List<Schema.Field> additionalRejectFields = cloneFields(inputSchema);
 
         field = new Schema.Field(FIELD_ERROR_CODE, Schema.create(Schema.Type.STRING), null, (Object) null);
         field.addProp(SchemaConstants.TALEND_IS_LOCKED, "false");
@@ -124,15 +149,10 @@ public class TSalesforceOutputProperties extends SalesforceOutputProperties {
         field.addProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH, "255");
         additionalRejectFields.add(field);
 
-        Schema rejectSchema = newSchema(inputSchema, "rejectOutput", additionalRejectFields);
-
-        schemaReject.schema.setValue(rejectSchema);
+        schemaReject.schema.setValue(newSchema(inputSchema, "rejectOutput", additionalRejectFields));
     }
 
-    private Schema newSchema(Schema metadataSchema, String newSchemaName, List<Schema.Field> moreFields) {
-        Schema newSchema = Schema.createRecord(newSchemaName, metadataSchema.getDoc(), metadataSchema.getNamespace(),
-                metadataSchema.isError());
-
+    private List<Schema.Field> cloneFields(Schema metadataSchema) {
         List<Schema.Field> copyFieldList = new ArrayList<>();
         for (Schema.Field se : metadataSchema.getFields()) {
             Schema.Field field = new Schema.Field(se.name(), se.schema(), se.doc(), se.defaultVal(), se.order());
@@ -143,9 +163,13 @@ public class TSalesforceOutputProperties extends SalesforceOutputProperties {
             copyFieldList.add(field);
         }
 
-        copyFieldList.addAll(moreFields);
+        return copyFieldList;
+    }
 
-        newSchema.setFields(copyFieldList);
+    private Schema newSchema(Schema metadataSchema, String newSchemaName, List<Schema.Field> moreFields) {
+        Schema newSchema = Schema.createRecord(newSchemaName, metadataSchema.getDoc(), metadataSchema.getNamespace(),
+                metadataSchema.isError());
+        newSchema.setFields(moreFields);
         for (Map.Entry<String, Object> entry : metadataSchema.getObjectProps().entrySet()) {
             newSchema.addProp(entry.getKey(), entry.getValue());
         }
@@ -176,6 +200,7 @@ public class TSalesforceOutputProperties extends SalesforceOutputProperties {
         updateOutputSchemas();
     }
 
+    @Override
     public void afterOutputAction() {
         super.afterOutputAction();
         updateOutputSchemas();

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -103,7 +103,7 @@ public class TSalesforceOutputDefinitionTest extends SalesforceTestBase {
 
     @Test
     public void testSchemaAutoPropagate() {
-        assertFalse(definition.isSchemaAutoPropagate());
+        assertTrue(definition.isSchemaAutoPropagate());
     }
 
     @Test


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-37641
Update schema may not have Id field.
Delete schema may contain more than 1 field - Id.

**What is the new behavior?**
Id field always present for Update action except dynamic schema.
Delete action contains only 1 field - Id
Changes only for design part.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
