### PR TITLE
fix(TDI-40819): Null values in dynamic schema

### DIFF
--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriter.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriter.java
@@ -27,6 +27,7 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.api.component.runtime.Result;
 import org.talend.components.api.component.runtime.WriteOperation;
 import org.talend.components.api.component.runtime.WriterWithFeedback;
@@ -145,7 +146,8 @@ public class SnowflakeWriter implements WriterWithFeedback<Result, IndexedRecord
             Field f = collectedFields.get(i);
             Field remoteTableField = remoteTableFields.get(i);
             if (f == null) {
-                row[i] = remoteTableField.defaultVal();
+                Object defaultValue = remoteTableField.defaultVal();
+                row[i] = StringUtils.EMPTY.equals(defaultValue) ? null : defaultValue;
                 continue;
             }
             Object inputValue = input.get(f.pos());


### PR DESCRIPTION
* fixed null values in tSnowflakeOutput with dynamic schema after update
to new driver version

**What is the current behavior?** (You can also link to an open issue here)

After upgrade to new driver empty string values became escaped and empty string values now are used in case values for some of the fields are absent in tSnowflakeOutput

**What is the new behavior?**

If value for the field is absent - use null value which will be parsed as an empty string in new version of snowflake-jdbc.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
