### PR TITLE
Ypiel/tdi 40793 set read only exception catch backport 0.23

### DIFF
--- a/components-parent/components-p2update-assembly/pom.xml
+++ b/components-parent/components-p2update-assembly/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-p2update-assembly</artifactId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<name>Assembly for building P2 updatesite for components</name>
     <properties>
         <talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>

--- a/components-parent/components-p2update-assembly/pom.xml
+++ b/components-parent/components-p2update-assembly/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-p2update-assembly</artifactId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<name>Assembly for building P2 updatesite for components</name>
     <properties>
         <talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>

--- a/components-parent/components-p2update-assembly/pom.xml
+++ b/components-parent/components-p2update-assembly/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-p2update-assembly</artifactId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<name>Assembly for building P2 updatesite for components</name>
     <properties>
         <talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>

--- a/components-parent/components-p2update-assembly/pom.xml
+++ b/components-parent/components-p2update-assembly/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-p2update-assembly</artifactId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<name>Assembly for building P2 updatesite for components</name>
     <properties>
         <talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>

--- a/components-parent/components-p2update-assembly/pom.xml
+++ b/components-parent/components-p2update-assembly/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-p2update-assembly</artifactId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<name>Assembly for building P2 updatesite for components</name>
     <properties>
         <talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <artifactId>components-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Component Parent POM</name>
     <properties>
@@ -15,7 +15,7 @@
         <!-- version properties will go to some bom pom -->
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <avro.version>1.8.1</avro.version>
-        <components.version>0.23.1-SNAPSHOT</components.version>
+        <components.version>0.23.1</components.version>
         <daikon.version>0.23.0</daikon.version>
         <guava.version>19.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <artifactId>components-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Component Parent POM</name>
     <properties>
@@ -15,7 +15,7 @@
         <!-- version properties will go to some bom pom -->
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <avro.version>1.8.1</avro.version>
-        <components.version>0.23.1</components.version>
+        <components.version>0.23.2-SNAPSHOT</components.version>
         <daikon.version>0.23.0</daikon.version>
         <guava.version>19.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <artifactId>components-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Component Parent POM</name>
     <properties>
@@ -15,7 +15,7 @@
         <!-- version properties will go to some bom pom -->
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <avro.version>1.8.1</avro.version>
-        <components.version>0.23.2</components.version>
+        <components.version>0.23.3-SNAPSHOT</components.version>
         <daikon.version>0.23.0</daikon.version>
         <guava.version>19.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <artifactId>components-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Component Parent POM</name>
     <properties>
@@ -15,7 +15,7 @@
         <!-- version properties will go to some bom pom -->
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <avro.version>1.8.1</avro.version>
-        <components.version>0.23.2-SNAPSHOT</components.version>
+        <components.version>0.23.2</components.version>
         <daikon.version>0.23.0</daikon.version>
         <guava.version>19.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <artifactId>components-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Component Parent POM</name>
     <properties>
@@ -15,8 +15,8 @@
         <!-- version properties will go to some bom pom -->
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <avro.version>1.8.1</avro.version>
-        <components.version>0.22.0-SNAPSHOT</components.version>
-        <daikon.version>0.23.0-SNAPSHOT</daikon.version>
+        <components.version>0.23.1-SNAPSHOT</components.version>
+        <daikon.version>0.23.0</daikon.version>
         <guava.version>19.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <org.json.version>20131018</org.json.version>

--- a/components/components-azurestorage/pom.xml
+++ b/components/components-azurestorage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-azurestorage</artifactId>

--- a/components/components-azurestorage/pom.xml
+++ b/components/components-azurestorage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-azurestorage</artifactId>

--- a/components/components-azurestorage/pom.xml
+++ b/components/components-azurestorage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-azurestorage</artifactId>

--- a/components/components-azurestorage/pom.xml
+++ b/components/components-azurestorage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-azurestorage</artifactId>

--- a/components/components-azurestorage/pom.xml
+++ b/components/components-azurestorage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-azurestorage</artifactId>

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriter.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriter.java
@@ -137,7 +137,7 @@ public class AzureStorageQueueWriter implements WriterWithFeedback<Result, Index
         return result;
     }
 
-    private void sendParallelMessages() {
+    private synchronized void sendParallelMessages() {
         messagesBuffer.parallelStream().forEach(new Consumer<QueueMessage>() {
 
             @Override

--- a/components/components-bigquery/bigquery-definition/pom.xml
+++ b/components/components-bigquery/bigquery-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-definition/pom.xml
+++ b/components/components-bigquery/bigquery-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-definition/pom.xml
+++ b/components/components-bigquery/bigquery-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-definition/pom.xml
+++ b/components/components-bigquery/bigquery-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-definition/pom.xml
+++ b/components/components-bigquery/bigquery-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-integration/pom.xml
+++ b/components/components-bigquery/bigquery-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-runtime/pom.xml
+++ b/components/components-bigquery/bigquery-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-runtime/pom.xml
+++ b/components/components-bigquery/bigquery-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-runtime/pom.xml
+++ b/components/components-bigquery/bigquery-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-runtime/pom.xml
+++ b/components/components-bigquery/bigquery-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/bigquery-runtime/pom.xml
+++ b/components/components-bigquery/bigquery-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-bigquery/pom.xml
+++ b/components/components-bigquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>components-implementation-aggregator</artifactId>
 		<groupId>org.talend.components</groupId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 	</parent>
 
     <groupId>org.talend.components</groupId>

--- a/components/components-bigquery/pom.xml
+++ b/components/components-bigquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>components-implementation-aggregator</artifactId>
 		<groupId>org.talend.components</groupId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 	</parent>
 
     <groupId>org.talend.components</groupId>

--- a/components/components-bigquery/pom.xml
+++ b/components/components-bigquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>components-implementation-aggregator</artifactId>
 		<groupId>org.talend.components</groupId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 	</parent>
 
     <groupId>org.talend.components</groupId>

--- a/components/components-bigquery/pom.xml
+++ b/components/components-bigquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>components-implementation-aggregator</artifactId>
 		<groupId>org.talend.components</groupId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 	</parent>
 
     <groupId>org.talend.components</groupId>

--- a/components/components-bigquery/pom.xml
+++ b/components/components-bigquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>components-implementation-aggregator</artifactId>
 		<groupId>org.talend.components</groupId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 	</parent>
 
     <groupId>org.talend.components</groupId>

--- a/components/components-couchbase/pom.xml
+++ b/components/components-couchbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-couchbase/pom.xml
+++ b/components/components-couchbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-couchbase/pom.xml
+++ b/components/components-couchbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-couchbase/pom.xml
+++ b/components/components-couchbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-couchbase/pom.xml
+++ b/components/components-couchbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-definition/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-definition/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-definition/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-definition/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-definition/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-integration/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-elasticsearch/elasticsearch-integration/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-elasticsearch/elasticsearch-integration/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-elasticsearch/elasticsearch-integration/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-elasticsearch/elasticsearch-integration/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-elasticsearch/pom.xml
+++ b/components/components-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-elasticsearch-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Elasticsearch Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-elasticsearch/pom.xml
+++ b/components/components-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-elasticsearch-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Elasticsearch Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-elasticsearch/pom.xml
+++ b/components/components-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-elasticsearch-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Elasticsearch Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-elasticsearch/pom.xml
+++ b/components/components-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-elasticsearch-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Elasticsearch Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-elasticsearch/pom.xml
+++ b/components/components-elasticsearch/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-elasticsearch-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Elasticsearch Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-filedelimited/pom.xml
+++ b/components/components-filedelimited/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-filedelimited/pom.xml
+++ b/components/components-filedelimited/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-filedelimited/pom.xml
+++ b/components/components-filedelimited/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-filedelimited/pom.xml
+++ b/components/components-filedelimited/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-filedelimited/pom.xml
+++ b/components/components-filedelimited/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/fileio-integration/pom.xml
+++ b/components/components-fileio/fileio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/fileio-integration/pom.xml
+++ b/components/components-fileio/fileio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/fileio-integration/pom.xml
+++ b/components/components-fileio/fileio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/fileio-integration/pom.xml
+++ b/components/components-fileio/fileio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/fileio-integration/pom.xml
+++ b/components/components-fileio/fileio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/pom.xml
+++ b/components/components-fileio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-fileio-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - File IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-fileio/pom.xml
+++ b/components/components-fileio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-fileio-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - File IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-fileio/pom.xml
+++ b/components/components-fileio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-fileio-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - File IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-fileio/pom.xml
+++ b/components/components-fileio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-fileio-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - File IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-fileio/pom.xml
+++ b/components/components-fileio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-fileio-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - File IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/s3-runtime-di/pom.xml
+++ b/components/components-fileio/s3-runtime-di/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-definition/pom.xml
+++ b/components/components-fileio/simplefileio-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-definition/pom.xml
+++ b/components/components-fileio/simplefileio-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-definition/pom.xml
+++ b/components/components-fileio/simplefileio-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-definition/pom.xml
+++ b/components/components-fileio/simplefileio-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-definition/pom.xml
+++ b/components/components-fileio/simplefileio-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-fileio/simplefileio-runtime/pom.xml
+++ b/components/components-fileio/simplefileio-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-filterrow/pom.xml
+++ b/components/components-filterrow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-filterrow/pom.xml
+++ b/components/components-filterrow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-filterrow/pom.xml
+++ b/components/components-filterrow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-filterrow/pom.xml
+++ b/components/components-filterrow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-filterrow/pom.xml
+++ b/components/components-filterrow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-googledrive/components-googledrive-definition/pom.xml
+++ b/components/components-googledrive/components-googledrive-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-definition</artifactId>

--- a/components/components-googledrive/components-googledrive-definition/pom.xml
+++ b/components/components-googledrive/components-googledrive-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-definition</artifactId>

--- a/components/components-googledrive/components-googledrive-definition/pom.xml
+++ b/components/components-googledrive/components-googledrive-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-definition</artifactId>

--- a/components/components-googledrive/components-googledrive-definition/pom.xml
+++ b/components/components-googledrive/components-googledrive-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-definition</artifactId>

--- a/components/components-googledrive/components-googledrive-definition/pom.xml
+++ b/components/components-googledrive/components-googledrive-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-definition</artifactId>

--- a/components/components-googledrive/components-googledrive-integration/pom.xml
+++ b/components/components-googledrive/components-googledrive-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-integration</artifactId>

--- a/components/components-googledrive/components-googledrive-integration/pom.xml
+++ b/components/components-googledrive/components-googledrive-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-integration</artifactId>

--- a/components/components-googledrive/components-googledrive-integration/pom.xml
+++ b/components/components-googledrive/components-googledrive-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-integration</artifactId>

--- a/components/components-googledrive/components-googledrive-integration/pom.xml
+++ b/components/components-googledrive/components-googledrive-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-integration</artifactId>

--- a/components/components-googledrive/components-googledrive-integration/pom.xml
+++ b/components/components-googledrive/components-googledrive-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-integration</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/pom.xml
+++ b/components/components-googledrive/components-googledrive-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-runtime</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/pom.xml
+++ b/components/components-googledrive/components-googledrive-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-runtime</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/pom.xml
+++ b/components/components-googledrive/components-googledrive-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-runtime</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/pom.xml
+++ b/components/components-googledrive/components-googledrive-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-runtime</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/pom.xml
+++ b/components/components-googledrive/components-googledrive-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-googledrive-runtime</artifactId>

--- a/components/components-googledrive/components-googledrive-runtime/src/main/resources/org/talend/components/google/drive/runtime/messages.properties
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/resources/org/talend/components/google/drive/runtime/messages.properties
@@ -46,3 +46,6 @@ error.file.inexistant=File `{0}` does not exist.
 error.file.already.exist=File `{0}` already exists.
 error.filefolder.inexistant=File/Folder `{0}` does not exist.
 error.filefolder.more.than.one=More than one file or folder found with name `{0}`.
+#
+error.testConnection.failure=Connection failure: {0}.
+error.testConnection.timeout=Connection Timeout (30s).

--- a/components/components-googledrive/pom.xml
+++ b/components/components-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-googledrive-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
     <name>Components - Google Drive Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-googledrive/pom.xml
+++ b/components/components-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-googledrive-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
     <name>Components - Google Drive Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-googledrive/pom.xml
+++ b/components/components-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-googledrive-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
     <name>Components - Google Drive Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-googledrive/pom.xml
+++ b/components/components-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-googledrive-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
     <name>Components - Google Drive Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-googledrive/pom.xml
+++ b/components/components-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-googledrive-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
     <name>Components - Google Drive Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-hadoopcluster/pom.xml
+++ b/components/components-hadoopcluster/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-hadoopcluster-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Hadoop Cluster Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-hadoopcluster/pom.xml
+++ b/components/components-hadoopcluster/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-hadoopcluster-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Hadoop Cluster Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-hadoopcluster/pom.xml
+++ b/components/components-hadoopcluster/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-hadoopcluster-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Hadoop Cluster Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-hadoopcluster/pom.xml
+++ b/components/components-hadoopcluster/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-hadoopcluster-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Hadoop Cluster Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-hadoopcluster/pom.xml
+++ b/components/components-hadoopcluster/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-hadoopcluster-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Hadoop Cluster Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jdbc/components-jdbc-definition/pom.xml
+++ b/components/components-jdbc/components-jdbc-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-jdbc/components-jdbc-definition/pom.xml
+++ b/components/components-jdbc/components-jdbc-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-jdbc/components-jdbc-definition/pom.xml
+++ b/components/components-jdbc/components-jdbc-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-jdbc/components-jdbc-definition/pom.xml
+++ b/components/components-jdbc/components-jdbc-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-jdbc/components-jdbc-definition/pom.xml
+++ b/components/components-jdbc/components-jdbc-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-jdbc/components-jdbc-integration/pom.xml
+++ b/components/components-jdbc/components-jdbc-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-integration/pom.xml
+++ b/components/components-jdbc/components-jdbc-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-integration/pom.xml
+++ b/components/components-jdbc/components-jdbc-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-integration/pom.xml
+++ b/components/components-jdbc/components-jdbc-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-integration/pom.xml
+++ b/components/components-jdbc/components-jdbc-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-adapter-beam-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-adapter-beam-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-adapter-beam-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-adapter-beam-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime-beam/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-adapter-beam-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/components-jdbc/components-jdbc-runtime/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jdbc/components-jdbc-runtime/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jdbc/components-jdbc-runtime/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jdbc/components-jdbc-runtime/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jdbc/components-jdbc-runtime/pom.xml
+++ b/components/components-jdbc/components-jdbc-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
@@ -195,7 +195,7 @@ public class JdbcRuntimeUtils {
             if (readonly) {
                 try {
                     conn.setReadOnly(setting.isReadOnly());
-                } catch (SQLFeatureNotSupportedException e) {
+                } catch (SQLException e) {
                     LOGGER.debug("JDBC driver '{}' does not support read only mode.", setting.getDriverClass(), e);
                 }
             }

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/common/DBTestUtils.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/common/DBTestUtils.java
@@ -329,12 +329,10 @@ public class DBTestUtils {
         }
     }
 
-    public static void createTableWithSpecialName(AllSetting allSetting, String tablename)
+    public static void createTableWithSpecialName(Connection conn, String tablename)
             throws SQLException, ClassNotFoundException {
-        try (Connection conn = JdbcRuntimeUtils.createConnection(allSetting)) {
-            try (Statement statement = conn.createStatement()) {
-                statement.execute("CREATE TABLE " + tablename + " (P1_Vente_Qté INT)");
-            }
+        try (Statement statement = conn.createStatement()) {
+            statement.execute("CREATE TABLE " + tablename + " (P1_Vente_Qté INT, \"Customer Id\" INT)");
         }
     }
 
@@ -1027,4 +1025,15 @@ public class DBTestUtils {
         mappings_url = new URL(mappings_url.getProtocol(),mappings_url.getHost(),mappings_url.getPort(),file_path);
         return mappings_url;
     }
+    
+    public static void testMetadata4SpecialName(List<Field> columns) {
+      Schema.Field field = columns.get(0);
+
+      assertEquals("P1_VENTE_QT_", field.name());
+      assertEquals("P1_VENTE_QTÉ", field.getObjectProp(SchemaConstants.TALEND_COLUMN_DB_COLUMN_NAME));
+      
+      field = columns.get(1);
+      assertEquals("Customer_Id", field.name());
+      assertEquals("Customer Id", field.getObjectProp(SchemaConstants.TALEND_COLUMN_DB_COLUMN_NAME));
+  }
 }

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/schema/JDBCSchemaTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/schema/JDBCSchemaTestIT.java
@@ -45,7 +45,9 @@ public class JDBCSchemaTestIT {
     public static void beforeClass() throws Exception {
         allSetting = DBTestUtils.createAllSetting();
 
-        DBTestUtils.createTableWithSpecialName(allSetting,tablename);
+        try (Connection conn = JdbcRuntimeUtils.createConnection(allSetting)) {
+          DBTestUtils.createTableWithSpecialName(conn,tablename);
+        }
     }
 
     @AfterClass
@@ -81,21 +83,7 @@ public class JDBCSchemaTestIT {
         Schema schema = source.getEndpointSchema(container, tablename);
         assertEquals(tablename, schema.getName().toUpperCase());
         List<Field> columns = schema.getFields();
-        testMetadata(columns);
+        DBTestUtils.testMetadata4SpecialName(columns);
     }
-
-    private void testMetadata(List<Field> columns) {
-        Schema.Field field = columns.get(0);
-
-        assertEquals("P1_VENTE_QT_", field.name());
-        assertEquals("P1_VENTE_QTÉ", field.getObjectProp(SchemaConstants.TALEND_COLUMN_DB_COLUMN_NAME));
-        assertEquals(AvroUtils._int(), AvroUtils.unwrapIfNullable(field.schema()));
-        assertEquals("INTEGER", field.getObjectProp(SchemaConstants.TALEND_COLUMN_DB_TYPE));
-        assertEquals(null, field.getObjectProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH));
-        assertEquals(null, field.getObjectProp(SchemaConstants.TALEND_COLUMN_SCALE));
-        assertEquals(null, field.getObjectProp(SchemaConstants.TALEND_COLUMN_PATTERN));
-        assertEquals(null, field.getObjectProp(SchemaConstants.TALEND_COLUMN_DEFAULT));
-    }
-
 
 }

--- a/components/components-jdbc/pom.xml
+++ b/components/components-jdbc/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jdbc-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - JDBC Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jdbc/pom.xml
+++ b/components/components-jdbc/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jdbc-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - JDBC Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jdbc/pom.xml
+++ b/components/components-jdbc/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jdbc-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - JDBC Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jdbc/pom.xml
+++ b/components/components-jdbc/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jdbc-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - JDBC Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jdbc/pom.xml
+++ b/components/components-jdbc/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jdbc-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - JDBC Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jira/pom.xml
+++ b/components/components-jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jira/pom.xml
+++ b/components/components-jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jira/pom.xml
+++ b/components/components-jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jira/pom.xml
+++ b/components/components-jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jira/pom.xml
+++ b/components/components-jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-definition/pom.xml
+++ b/components/components-jms/jms-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-definition/pom.xml
+++ b/components/components-jms/jms-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-definition/pom.xml
+++ b/components/components-jms/jms-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-definition/pom.xml
+++ b/components/components-jms/jms-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-definition/pom.xml
+++ b/components/components-jms/jms-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-runtime_1_1/pom.xml
+++ b/components/components-jms/jms-runtime_1_1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-runtime_1_1/pom.xml
+++ b/components/components-jms/jms-runtime_1_1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-runtime_1_1/pom.xml
+++ b/components/components-jms/jms-runtime_1_1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-runtime_1_1/pom.xml
+++ b/components/components-jms/jms-runtime_1_1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/jms-runtime_1_1/pom.xml
+++ b/components/components-jms/jms-runtime_1_1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-jms/pom.xml
+++ b/components/components-jms/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jms-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - JMS Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jms/pom.xml
+++ b/components/components-jms/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jms-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - JMS Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jms/pom.xml
+++ b/components/components-jms/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jms-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - JMS Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jms/pom.xml
+++ b/components/components-jms/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jms-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - JMS Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-jms/pom.xml
+++ b/components/components-jms/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-jms-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - JMS Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kafka/kafka-definition/pom.xml
+++ b/components/components-kafka/kafka-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-definition/pom.xml
+++ b/components/components-kafka/kafka-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-definition/pom.xml
+++ b/components/components-kafka/kafka-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-definition/pom.xml
+++ b/components/components-kafka/kafka-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-definition/pom.xml
+++ b/components/components-kafka/kafka-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-integration/pom.xml
+++ b/components/components-kafka/kafka-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-integration/pom.xml
+++ b/components/components-kafka/kafka-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-integration/pom.xml
+++ b/components/components-kafka/kafka-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-integration/pom.xml
+++ b/components/components-kafka/kafka-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-integration/pom.xml
+++ b/components/components-kafka/kafka-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-runtime/pom.xml
+++ b/components/components-kafka/kafka-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-runtime/pom.xml
+++ b/components/components-kafka/kafka-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-runtime/pom.xml
+++ b/components/components-kafka/kafka-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-runtime/pom.xml
+++ b/components/components-kafka/kafka-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/kafka-runtime/pom.xml
+++ b/components/components-kafka/kafka-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kafka/pom.xml
+++ b/components/components-kafka/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kafka-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Kafka Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kafka/pom.xml
+++ b/components/components-kafka/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kafka-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Kafka Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kafka/pom.xml
+++ b/components/components-kafka/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kafka-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Kafka Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kafka/pom.xml
+++ b/components/components-kafka/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kafka-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Kafka Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kafka/pom.xml
+++ b/components/components-kafka/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kafka-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Kafka Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kinesis/kinesis-definition/pom.xml
+++ b/components/components-kinesis/kinesis-definition/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-definition/pom.xml
+++ b/components/components-kinesis/kinesis-definition/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-definition/pom.xml
+++ b/components/components-kinesis/kinesis-definition/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-definition/pom.xml
+++ b/components/components-kinesis/kinesis-definition/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-definition/pom.xml
+++ b/components/components-kinesis/kinesis-definition/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-integration/pom.xml
+++ b/components/components-kinesis/kinesis-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-integration/pom.xml
+++ b/components/components-kinesis/kinesis-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-integration/pom.xml
+++ b/components/components-kinesis/kinesis-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-integration/pom.xml
+++ b/components/components-kinesis/kinesis-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-integration/pom.xml
+++ b/components/components-kinesis/kinesis-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>components-parent</artifactId>
         <groupId>org.talend.components</groupId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-runtime/pom.xml
+++ b/components/components-kinesis/kinesis-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-runtime/pom.xml
+++ b/components/components-kinesis/kinesis-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-runtime/pom.xml
+++ b/components/components-kinesis/kinesis-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-runtime/pom.xml
+++ b/components/components-kinesis/kinesis-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/kinesis-runtime/pom.xml
+++ b/components/components-kinesis/kinesis-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-kinesis/pom.xml
+++ b/components/components-kinesis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kinesis-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Kinesis Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kinesis/pom.xml
+++ b/components/components-kinesis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kinesis-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Kinesis Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kinesis/pom.xml
+++ b/components/components-kinesis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kinesis-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Kinesis Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kinesis/pom.xml
+++ b/components/components-kinesis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kinesis-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Kinesis Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-kinesis/pom.xml
+++ b/components/components-kinesis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-kinesis-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Kinesis Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-localio/localio-definition/pom.xml
+++ b/components/components-localio/localio-definition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-definition/pom.xml
+++ b/components/components-localio/localio-definition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-definition/pom.xml
+++ b/components/components-localio/localio-definition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-definition/pom.xml
+++ b/components/components-localio/localio-definition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-definition/pom.xml
+++ b/components/components-localio/localio-definition/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-integration/pom.xml
+++ b/components/components-localio/localio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-localio/localio-integration/pom.xml
+++ b/components/components-localio/localio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-localio/localio-integration/pom.xml
+++ b/components/components-localio/localio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-localio/localio-integration/pom.xml
+++ b/components/components-localio/localio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-localio/localio-integration/pom.xml
+++ b/components/components-localio/localio-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-localio/localio-runtime/pom.xml
+++ b/components/components-localio/localio-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-adapter-beam-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-runtime/pom.xml
+++ b/components/components-localio/localio-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-adapter-beam-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-runtime/pom.xml
+++ b/components/components-localio/localio-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-adapter-beam-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-runtime/pom.xml
+++ b/components/components-localio/localio-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-adapter-beam-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/localio-runtime/pom.xml
+++ b/components/components-localio/localio-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-adapter-beam-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-localio/pom.xml
+++ b/components/components-localio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-localio-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Local IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-localio/pom.xml
+++ b/components/components-localio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-localio-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Local IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-localio/pom.xml
+++ b/components/components-localio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-localio-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Local IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-localio/pom.xml
+++ b/components/components-localio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-localio-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Local IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-localio/pom.xml
+++ b/components/components-localio/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-localio-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Local IO Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-marketo/components-marketo-definition/pom.xml
+++ b/components/components-marketo/components-marketo-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-definition</artifactId>

--- a/components/components-marketo/components-marketo-definition/pom.xml
+++ b/components/components-marketo/components-marketo-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-definition</artifactId>

--- a/components/components-marketo/components-marketo-definition/pom.xml
+++ b/components/components-marketo/components-marketo-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-definition</artifactId>

--- a/components/components-marketo/components-marketo-definition/pom.xml
+++ b/components/components-marketo/components-marketo-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-definition</artifactId>

--- a/components/components-marketo/components-marketo-definition/pom.xml
+++ b/components/components-marketo/components-marketo-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-definition</artifactId>

--- a/components/components-marketo/components-marketo-integration/pom.xml
+++ b/components/components-marketo/components-marketo-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-integration</artifactId>

--- a/components/components-marketo/components-marketo-integration/pom.xml
+++ b/components/components-marketo/components-marketo-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-integration</artifactId>

--- a/components/components-marketo/components-marketo-integration/pom.xml
+++ b/components/components-marketo/components-marketo-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-integration</artifactId>

--- a/components/components-marketo/components-marketo-integration/pom.xml
+++ b/components/components-marketo/components-marketo-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-integration</artifactId>

--- a/components/components-marketo/components-marketo-integration/pom.xml
+++ b/components/components-marketo/components-marketo-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-integration</artifactId>

--- a/components/components-marketo/components-marketo-runtime/pom.xml
+++ b/components/components-marketo/components-marketo-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-runtime</artifactId>

--- a/components/components-marketo/components-marketo-runtime/pom.xml
+++ b/components/components-marketo/components-marketo-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-runtime</artifactId>

--- a/components/components-marketo/components-marketo-runtime/pom.xml
+++ b/components/components-marketo/components-marketo-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-runtime</artifactId>

--- a/components/components-marketo/components-marketo-runtime/pom.xml
+++ b/components/components-marketo/components-marketo-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-runtime</artifactId>

--- a/components/components-marketo/components-marketo-runtime/pom.xml
+++ b/components/components-marketo/components-marketo-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
     <artifactId>components-marketo-runtime</artifactId>

--- a/components/components-marketo/pom.xml
+++ b/components/components-marketo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-marketo-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
     <name>Components - Marketo Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-marketo/pom.xml
+++ b/components/components-marketo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-marketo-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
     <name>Components - Marketo Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-marketo/pom.xml
+++ b/components/components-marketo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-marketo-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
     <name>Components - Marketo Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-marketo/pom.xml
+++ b/components/components-marketo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-marketo-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
     <name>Components - Marketo Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-marketo/pom.xml
+++ b/components/components-marketo/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.components</groupId>
     <artifactId>components-marketo-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
     <name>Components - Marketo Aggregator</name>
     <packaging>pom</packaging>
     <properties>

--- a/components/components-marklogic/components-marklogic-definition/pom.xml
+++ b/components/components-marklogic/components-marklogic-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-definition/pom.xml
+++ b/components/components-marklogic/components-marklogic-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-definition/pom.xml
+++ b/components/components-marklogic/components-marklogic-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-definition/pom.xml
+++ b/components/components-marklogic/components-marklogic-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-definition/pom.xml
+++ b/components/components-marklogic/components-marklogic-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-runtime/pom.xml
+++ b/components/components-marklogic/components-marklogic-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-runtime/pom.xml
+++ b/components/components-marklogic/components-marklogic-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-runtime/pom.xml
+++ b/components/components-marklogic/components-marklogic-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-runtime/pom.xml
+++ b/components/components-marklogic/components-marklogic-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/components-marklogic-runtime/pom.xml
+++ b/components/components-marklogic/components-marklogic-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-marklogic/pom.xml
+++ b/components/components-marklogic/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
         <groupId>org.talend.components</groupId>
     <artifactId>components-marklogic-aggregator</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
 
 
     <name>Components - MarkLogic Aggregator</name>

--- a/components/components-marklogic/pom.xml
+++ b/components/components-marklogic/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
         <groupId>org.talend.components</groupId>
     <artifactId>components-marklogic-aggregator</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
 
 
     <name>Components - MarkLogic Aggregator</name>

--- a/components/components-marklogic/pom.xml
+++ b/components/components-marklogic/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
         <groupId>org.talend.components</groupId>
     <artifactId>components-marklogic-aggregator</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
 
 
     <name>Components - MarkLogic Aggregator</name>

--- a/components/components-marklogic/pom.xml
+++ b/components/components-marklogic/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
         <groupId>org.talend.components</groupId>
     <artifactId>components-marklogic-aggregator</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
 
 
     <name>Components - MarkLogic Aggregator</name>

--- a/components/components-marklogic/pom.xml
+++ b/components/components-marklogic/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
         <groupId>org.talend.components</groupId>
     <artifactId>components-marklogic-aggregator</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
 
 
     <name>Components - MarkLogic Aggregator</name>

--- a/components/components-netsuite/components-netsuite-definition/pom.xml
+++ b/components/components-netsuite/components-netsuite-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-definition/pom.xml
+++ b/components/components-netsuite/components-netsuite-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-definition/pom.xml
+++ b/components/components-netsuite/components-netsuite-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-definition/pom.xml
+++ b/components/components-netsuite/components-netsuite-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-definition/pom.xml
+++ b/components/components-netsuite/components-netsuite-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-netsuite/pom.xml
+++ b/components/components-netsuite/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-netsuite-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - NetSuite Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-netsuite/pom.xml
+++ b/components/components-netsuite/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-netsuite-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - NetSuite Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-netsuite/pom.xml
+++ b/components/components-netsuite/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-netsuite-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - NetSuite Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-netsuite/pom.xml
+++ b/components/components-netsuite/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-netsuite-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - NetSuite Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-netsuite/pom.xml
+++ b/components/components-netsuite/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-netsuite-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - NetSuite Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-processing/pom.xml
+++ b/components/components-processing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/pom.xml
+++ b/components/components-processing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/pom.xml
+++ b/components/components-processing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/pom.xml
+++ b/components/components-processing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/pom.xml
+++ b/components/components-processing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-definition/pom.xml
+++ b/components/components-processing/processing-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-definition/pom.xml
+++ b/components/components-processing/processing-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-definition/pom.xml
+++ b/components/components-processing/processing-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-definition/pom.xml
+++ b/components/components-processing/processing-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-definition/pom.xml
+++ b/components/components-processing/processing-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pom.xml
+++ b/components/components-pubsub/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-pubsub-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - PubSub Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-pubsub/pom.xml
+++ b/components/components-pubsub/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-pubsub-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - PubSub Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-pubsub/pom.xml
+++ b/components/components-pubsub/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-pubsub-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - PubSub Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-pubsub/pom.xml
+++ b/components/components-pubsub/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-pubsub-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - PubSub Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-pubsub/pom.xml
+++ b/components/components-pubsub/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-pubsub-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - PubSub Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-pubsub/pubsub-definition/pom.xml
+++ b/components/components-pubsub/pubsub-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-definition/pom.xml
+++ b/components/components-pubsub/pubsub-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-definition/pom.xml
+++ b/components/components-pubsub/pubsub-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-definition/pom.xml
+++ b/components/components-pubsub/pubsub-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-definition/pom.xml
+++ b/components/components-pubsub/pubsub-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-integration/pom.xml
+++ b/components/components-pubsub/pubsub-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-integration/pom.xml
+++ b/components/components-pubsub/pubsub-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-integration/pom.xml
+++ b/components/components-pubsub/pubsub-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-integration/pom.xml
+++ b/components/components-pubsub/pubsub-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-integration/pom.xml
+++ b/components/components-pubsub/pubsub-integration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-runtime/pom.xml
+++ b/components/components-pubsub/pubsub-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-runtime/pom.xml
+++ b/components/components-pubsub/pubsub-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-runtime/pom.xml
+++ b/components/components-pubsub/pubsub-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-runtime/pom.xml
+++ b/components/components-pubsub/pubsub-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-pubsub/pubsub-runtime/pom.xml
+++ b/components/components-pubsub/pubsub-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-salesforce/components-salesforce-definition/pom.xml
+++ b/components/components-salesforce/components-salesforce-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-definition/pom.xml
+++ b/components/components-salesforce/components-salesforce-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-definition/pom.xml
+++ b/components/components-salesforce/components-salesforce-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-definition/pom.xml
+++ b/components/components-salesforce/components-salesforce-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-definition/pom.xml
+++ b/components/components-salesforce/components-salesforce-definition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionProperties.java
@@ -51,9 +51,13 @@ public class SalesforceConnectionProperties extends ComponentPropertiesImpl
 
     public static final String DEFAULT_API_VERSION = "42.0";
 
-    public static final String URL = "https://www.salesforce.com/services/Soap/u/" + DEFAULT_API_VERSION;
+    public static final String RETIRED_ENDPOINT = "www.salesforce.com";
 
-    public static final String OAUTH_URL = "https://login.salesforce.com/services/oauth2";
+    public static final String ACTIVE_ENDPOINT = "login.salesforce.com";
+
+    public static final String URL = "https://" + ACTIVE_ENDPOINT + "/services/Soap/u/" + DEFAULT_API_VERSION;
+
+    public static final String OAUTH_URL = "https://" + ACTIVE_ENDPOINT + "/services/oauth2";
 
     public Property<String> endpoint = newString("endpoint").setRequired();
 
@@ -174,8 +178,8 @@ public class SalesforceConnectionProperties extends ComponentPropertiesImpl
 
     public void afterLoginType() {
         updateEndpoint();
-        if(LoginType.OAuth.equals(loginType.getValue()) && oauth2FlowType.getValue() == null) {
-            oauth2FlowType.setValue(JWT_Flow); //set the default value
+        if (LoginType.OAuth.equals(loginType.getValue()) && oauth2FlowType.getValue() == null) {
+            oauth2FlowType.setValue(JWT_Flow); // set the default value
         }
 
         refreshLayout(getForm(Form.MAIN));

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
@@ -18,6 +18,7 @@ import static org.talend.components.salesforce.SalesforceDefinition.getSandboxed
 import static org.talend.daikon.properties.presentation.Widget.widget;
 import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.avro.Schema;
@@ -112,6 +113,7 @@ public class SalesforceModuleProperties extends ComponentPropertiesImpl implemen
                 try {
                     Schema schema = ss.getEndpointSchema(null, moduleName.getStringValue());
                     main.schema.setValue(schema);
+                    moduleName.setPossibleValues(Collections.emptyList());
                 } catch (Exception ex) {
                     throw new ComponentException(ExceptionUtil.exceptionToValidationResult(ex));
                 }

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
@@ -86,6 +86,8 @@ public class TSalesforceInputProperties extends SalesforceConnectionModuleProper
 
     public Property<Boolean> safetySwitch = newBoolean("safetySwitch", true);
 
+    public Property<Boolean> returnNullValue = newBoolean("returnNullValue", false);
+
     public Property<Integer> jobTimeOut = newInteger("jobTimeOut");
 
     public Property<Boolean> pkChunking = newBoolean("pkChunking", false);
@@ -144,6 +146,7 @@ public class TSalesforceInputProperties extends SalesforceConnectionModuleProper
 
         Form advancedForm = getForm(Form.ADVANCED);
         advancedForm.addRow(safetySwitch);
+        advancedForm.addRow(returnNullValue);
         advancedForm.addRow(jobTimeOut);
         advancedForm.addRow(pkChunking);
         advancedForm.addRow(chunkSize);
@@ -249,6 +252,7 @@ public class TSalesforceInputProperties extends SalesforceConnectionModuleProper
         if (Form.ADVANCED.equals(form.getName())) {
             boolean isBulkQuery = queryMode.getValue().equals(QueryMode.Bulk);
             form.getWidget(safetySwitch.getName()).setVisible(isBulkQuery);
+            form.getWidget(returnNullValue.getName()).setVisible(isBulkQuery);
             form.getWidget(jobTimeOut.getName()).setVisible(isBulkQuery);
             form.getWidget(pkChunking.getName()).setVisible(isBulkQuery);
             form.getWidget(chunkSize.getName()).setVisible(isBulkQuery && pkChunking.getValue());

--- a/components/components-salesforce/components-salesforce-definition/src/main/resources/org/talend/components/salesforce/tsalesforceinput/messages.properties
+++ b/components/components-salesforce/components-salesforce-definition/src/main/resources/org/talend/components/salesforce/tsalesforceinput/messages.properties
@@ -1,6 +1,7 @@
 property.name.displayName=Name
 property.queryMode.displayName=Query Mode
 property.safetySwitch.displayName=Safety Switch
+property.returnNullValue.displayName=All return null if value is empty
 property.jobTimeOut.displayName=Complete Job timeout
 property.pkChunking.displayName=Enable PK Chunking
 property.chunkSize.displayName=Chunk size

--- a/components/components-salesforce/components-salesforce-integration/pom.xml
+++ b/components/components-salesforce/components-salesforce-integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-salesforce/components-salesforce-integration/pom.xml
+++ b/components/components-salesforce/components-salesforce-integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-salesforce/components-salesforce-integration/pom.xml
+++ b/components/components-salesforce/components-salesforce-integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-salesforce/components-salesforce-integration/pom.xml
+++ b/components/components-salesforce/components-salesforce-integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-salesforce/components-salesforce-integration/pom.xml
+++ b/components/components-salesforce/components-salesforce-integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceInputReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceInputReaderTestIT.java
@@ -85,7 +85,8 @@ public class SalesforceInputReaderTestIT extends SalesforceTestBase {
             .name("BillingCity").type().stringType().noDefault() //
             .name("BillingState").type().stringType().noDefault() //
             .name("NumberOfEmployees").type().intType().noDefault() //
-            .name("AnnualRevenue").type(AvroUtils._decimal()).noDefault().endRecord();
+            .name("AnnualRevenue").type(AvroUtils._decimal()).noDefault() //
+            .name("BillingCountry").type().bytesType().noDefault().endRecord();
 
     @Test
     public void testStartAdvanceGetCurrent() throws IOException {
@@ -220,7 +221,8 @@ public class SalesforceInputReaderTestIT extends SalesforceTestBase {
         try {
             List<IndexedRecord> rows = readRows(props);
             checkRows(random, rows, count);
-            testBulkQueryNullValue(props, random);
+            // Some tests are duplicates, reuse some test for return all empty value as null test
+            testBulkQueryNullValue(props, random, !emptySchema);
         } finally {
             deleteRows(outputRows, props);
         }
@@ -589,7 +591,7 @@ public class SalesforceInputReaderTestIT extends SalesforceTestBase {
         }
     }
 
-    protected void testBulkQueryNullValue(SalesforceConnectionModuleProperties props, String random) throws Throwable {
+    protected void testBulkQueryNullValue(SalesforceConnectionModuleProperties props, String random,boolean returnNullForEmpty) throws Throwable {
         ComponentDefinition sfInputDef = new TSalesforceInputDefinition();
         TSalesforceInputProperties sfInputProps = (TSalesforceInputProperties) sfInputDef.createRuntimeProperties();
         sfInputProps.copyValuesFrom(props);
@@ -597,11 +599,22 @@ public class SalesforceInputReaderTestIT extends SalesforceTestBase {
         sfInputProps.module.main.schema.setValue(SCHEMA_QUERY_ACCOUNT);
         sfInputProps.queryMode.setValue(TSalesforceInputProperties.QueryMode.Bulk);
         sfInputProps.condition.setValue("BillingPostalCode = '" + random + "'");
+        sfInputProps.returnNullValue.setValue(returnNullForEmpty);
 
         List<IndexedRecord> inpuRecords = readRows(sfInputProps);
         for (IndexedRecord record : inpuRecords) {
+            if (returnNullForEmpty) {
+                assertNull(record.get(3));
+            } else {
+                assertNotNull(record.get(3));
+            }
             assertNull(record.get(5));
             assertNull(record.get(6));
+            if (returnNullForEmpty) {
+                assertNull(record.get(7));
+            } else {
+                assertNotNull(record.get(7));
+            }
         }
     }
 

--- a/components/components-salesforce/components-salesforce-runtime/pom.xml
+++ b/components/components-salesforce/components-salesforce-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-runtime/pom.xml
+++ b/components/components-salesforce/components-salesforce-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-runtime/pom.xml
+++ b/components/components-salesforce/components-salesforce-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-runtime/pom.xml
+++ b/components/components-salesforce/components-salesforce-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-runtime/pom.xml
+++ b/components/components-salesforce/components-salesforce-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/BulkResultAdapterFactory.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/BulkResultAdapterFactory.java
@@ -25,6 +25,8 @@ public class BulkResultAdapterFactory implements IndexedRecordConverter<BulkResu
 
     private String names[];
 
+    private boolean returnNullForEmpty;
+
     /** The cached AvroConverter objects for the fields of this record. */
     @SuppressWarnings("rawtypes")
     protected transient AvroConverter[] fieldConverter;
@@ -52,6 +54,8 @@ public class BulkResultAdapterFactory implements IndexedRecordConverter<BulkResu
     @Override
     public void setSchema(Schema schema) {
         this.schema = schema;
+        Object propValue = schema.getObjectProp(SalesforceSchemaConstants.RETURN_NULL_FOR_EMPTY);
+        this.returnNullForEmpty = (propValue == null) ? false : (Boolean) propValue;
     }
 
     private class ResultIndexedRecord implements IndexedRecord {
@@ -84,6 +88,9 @@ public class BulkResultAdapterFactory implements IndexedRecordConverter<BulkResu
             if (resultValue == null) {
                 String columnName = names[i].substring(names[i].indexOf("_") + 1);
                 resultValue = value.getValue(columnName);
+            }
+            if (returnNullForEmpty && resultValue != null && "".equals(resultValue)) {
+                resultValue = null;
             }
             return fieldConverter[i].convertToAvro(resultValue);
         }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceReader.java
@@ -70,6 +70,7 @@ public abstract class SalesforceReader<T> extends AbstractBoundedReader<T> {
 
     protected IndexedRecordConverter<?, IndexedRecord> getFactory() throws IOException {
         if (null == factory) {
+            Schema schema = getSchema();
             boolean useBulkFactory = false;
             if (properties instanceof TSalesforceBulkExecProperties) {
                 useBulkFactory = true;
@@ -77,6 +78,10 @@ public abstract class SalesforceReader<T> extends AbstractBoundedReader<T> {
                 if (TSalesforceInputProperties.QueryMode.Bulk
                         .equals(((TSalesforceInputProperties) properties).queryMode.getValue())) {
                     useBulkFactory = true;
+                    if (((TSalesforceInputProperties) properties).returnNullValue.getValue()) {
+                        schema.addProp(SalesforceSchemaConstants.RETURN_NULL_FOR_EMPTY, true);
+                    }
+
                 }
             }
             if (useBulkFactory) {
@@ -84,7 +89,7 @@ public abstract class SalesforceReader<T> extends AbstractBoundedReader<T> {
             } else {
                 factory = new SObjectAdapterFactory();
             }
-            factory.setSchema(getSchema());
+            factory.setSchema(schema);
         }
         return factory;
     }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSchemaConstants.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSchemaConstants.java
@@ -24,4 +24,6 @@ public abstract class SalesforceSchemaConstants {
     public final static String COLUMNNAME_DELIMTER = "salesforce.column.delimiter";
 
     public final static String VALUE_DELIMITER = "salesforce.value.delimiter";
+
+    public final static String RETURN_NULL_FOR_EMPTY = "RETURN_NULL_FOR_EMPTY";
 }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
@@ -167,6 +167,10 @@ public class SalesforceSourceOrSink implements SalesforceRuntimeSourceOrSink, Sa
         } else {
             SalesforceConnectionProperties connProps = getConnectionProperties();
             String endpoint = connProps.endpoint.getStringValue();
+            if (endpoint != null && endpoint.contains(SalesforceConnectionProperties.RETIRED_ENDPOINT)) {
+                endpoint = endpoint.replaceFirst(SalesforceConnectionProperties.RETIRED_ENDPOINT,
+                        SalesforceConnectionProperties.ACTIVE_ENDPOINT);
+            }
             endpoint = StringUtils.strip(endpoint, "\"");
             if (SalesforceConnectionProperties.LoginType.OAuth.equals(connProps.loginType.getValue())) {
                 SalesforceOAuthConnection oauthConnection = new SalesforceOAuthConnection(connProps, endpoint,

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriter.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriter.java
@@ -447,7 +447,7 @@ final class SalesforceWriter implements WriterWithFeedback<Result, IndexedRecord
                                 handleSuccess(upsertItems.get(i), upsertResults[i].getId(), "updated");
                             }
                         } else {
-                            handleReject(upsertItems.get(0), upsertResults[i].getErrors(), changedItemKeys, batch_idx);
+                            handleReject(upsertItems.get(i), upsertResults[i].getErrors(), changedItemKeys, batch_idx);
                         }
                     }
                 }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
@@ -94,6 +94,10 @@ public class SalesforceDataprepSource
 
             String endpoint = props.getProperty("endpoint");
             if (endpoint != null && !endpoint.isEmpty()) {
+                if (endpoint.contains(SalesforceConnectionProperties.RETIRED_ENDPOINT)) {
+                    endpoint = endpoint.replaceFirst(SalesforceConnectionProperties.RETIRED_ENDPOINT,
+                            SalesforceConnectionProperties.ACTIVE_ENDPOINT);
+                }
                 this.endpoint = endpoint;
             }
 

--- a/components/components-salesforce/pom.xml
+++ b/components/components-salesforce/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-salesforce-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Salesforce Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-salesforce/pom.xml
+++ b/components/components-salesforce/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-salesforce-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Salesforce Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-salesforce/pom.xml
+++ b/components/components-salesforce/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-salesforce-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Salesforce Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-salesforce/pom.xml
+++ b/components/components-salesforce/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-salesforce-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Salesforce Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-salesforce/pom.xml
+++ b/components/components-salesforce/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-salesforce-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Salesforce Aggregator</name>
     <packaging>pom</packaging>

--- a/components/components-snowflake/pom.xml
+++ b/components/components-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-snowflake/pom.xml
+++ b/components/components-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-snowflake/pom.xml
+++ b/components/components-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-snowflake/pom.xml
+++ b/components/components-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-snowflake/pom.xml
+++ b/components/components-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/components/components-snowflake/src/main/java/org/talend/components/snowflake/SnowflakeTableProperties.java
+++ b/components/components-snowflake/src/main/java/org/talend/components/snowflake/SnowflakeTableProperties.java
@@ -15,6 +15,7 @@ package org.talend.components.snowflake;
 import static org.talend.daikon.properties.presentation.Widget.widget;
 import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.talend.components.api.component.ISchemaListener;
@@ -91,6 +92,7 @@ public class SnowflakeTableProperties extends ComponentPropertiesImpl implements
         ValidationResultMutable vr = new ValidationResultMutable();
         try {
             main.schema.setValue(SnowflakeSourceOrSink.getSchema(null, connection, tableName.getValue()));
+            tableName.setPossibleValues(Collections.emptyList());
         } catch (Exception ex) {
             vr.setMessage(ex.getMessage());
             vr.setStatus(ValidationResult.Result.ERROR);

--- a/components/components-splunk/pom.xml
+++ b/components/components-splunk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-splunk/pom.xml
+++ b/components/components-splunk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-splunk/pom.xml
+++ b/components/components-splunk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-splunk/pom.xml
+++ b/components/components-splunk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/components-splunk/pom.xml
+++ b/components/components-splunk/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Implementations Aggregator</name>
     <artifactId>components-implementation-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Implementations Aggregator</name>
     <artifactId>components-implementation-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Implementations Aggregator</name>
     <artifactId>components-implementation-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Implementations Aggregator</name>
     <artifactId>components-implementation-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Implementations Aggregator</name>
     <artifactId>components-implementation-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam-parent/pom.xml
+++ b/core/components-adapter-beam-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-adapter-beam/pom.xml
+++ b/core/components-adapter-beam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-api-proptester/pom.xml
+++ b/core/components-api-proptester/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/components-api-proptester/pom.xml
+++ b/core/components-api-proptester/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/components-api-proptester/pom.xml
+++ b/core/components-api-proptester/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/components-api-proptester/pom.xml
+++ b/core/components-api-proptester/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/components-api-proptester/pom.xml
+++ b/core/components-api-proptester/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/components-api/pom.xml
+++ b/core/components-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-api/pom.xml
+++ b/core/components-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-api/pom.xml
+++ b/core/components-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-api/pom.xml
+++ b/core/components-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-api/pom.xml
+++ b/core/components-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common-oauth/pom.xml
+++ b/core/components-common-oauth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common-oauth/pom.xml
+++ b/core/components-common-oauth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common-oauth/pom.xml
+++ b/core/components-common-oauth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common-oauth/pom.xml
+++ b/core/components-common-oauth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common-oauth/pom.xml
+++ b/core/components-common-oauth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-common/pom.xml
+++ b/core/components-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-common/pom.xml
+++ b/core/components-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-common/pom.xml
+++ b/core/components-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-common/pom.xml
+++ b/core/components-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-common/pom.xml
+++ b/core/components-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/components-osgi-test/components-osgitest/pom.xml
+++ b/core/components-osgi-test/components-osgitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/components-osgitest/pom.xml
+++ b/core/components-osgi-test/components-osgitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/components-osgitest/pom.xml
+++ b/core/components-osgi-test/components-osgitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/components-osgitest/pom.xml
+++ b/core/components-osgi-test/components-osgitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/components-osgitest/pom.xml
+++ b/core/components-osgi-test/components-osgitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/osgi-test-component/pom.xml
+++ b/core/components-osgi-test/osgi-test-component/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/osgi-test-component/pom.xml
+++ b/core/components-osgi-test/osgi-test-component/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/osgi-test-component/pom.xml
+++ b/core/components-osgi-test/osgi-test-component/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/osgi-test-component/pom.xml
+++ b/core/components-osgi-test/osgi-test-component/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/osgi-test-component/pom.xml
+++ b/core/components-osgi-test/osgi-test-component/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/core/components-osgi-test/pom.xml
+++ b/core/components-osgi-test/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-osgi-test-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Components - Osgi test Aggregator</name>
     <packaging>pom</packaging>

--- a/core/components-osgi-test/pom.xml
+++ b/core/components-osgi-test/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-osgi-test-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Components - Osgi test Aggregator</name>
     <packaging>pom</packaging>

--- a/core/components-osgi-test/pom.xml
+++ b/core/components-osgi-test/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-osgi-test-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Components - Osgi test Aggregator</name>
     <packaging>pom</packaging>

--- a/core/components-osgi-test/pom.xml
+++ b/core/components-osgi-test/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-osgi-test-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Components - Osgi test Aggregator</name>
     <packaging>pom</packaging>

--- a/core/components-osgi-test/pom.xml
+++ b/core/components-osgi-test/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-osgi-test-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Components - Osgi test Aggregator</name>
     <packaging>pom</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Core Aggregator</name>
     <artifactId>components-core-aggregator</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Core Aggregator</name>
     <artifactId>components-core-aggregator</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Core Aggregator</name>
     <artifactId>components-core-aggregator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Core Aggregator</name>
     <artifactId>components-core-aggregator</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.talend.components</groupId>
     <name>Component Core Aggregator</name>
     <artifactId>components-core-aggregator</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/examples/components-api-archetypes/bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/input-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/input-component-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/input-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/input-component-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/input-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/input-component-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/input-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/input-component-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/input-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/input-component-archetype/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/pom.xml
+++ b/examples/components-api-archetypes/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/pom.xml
+++ b/examples/components-api-archetypes/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/pom.xml
+++ b/examples/components-api-archetypes/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/pom.xml
+++ b/examples/components-api-archetypes/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/pom.xml
+++ b/examples/components-api-archetypes/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-adapter-beam-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../core/components-adapter-beam-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/components-api-full-example/pom.xml
+++ b/examples/components-api-full-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-full-example/pom.xml
+++ b/examples/components-api-full-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-full-example/pom.xml
+++ b/examples/components-api-full-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-full-example/pom.xml
+++ b/examples/components-api-full-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-api-full-example/pom.xml
+++ b/examples/components-api-full-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>		
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>		
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>		
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>		
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>		
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<artifactId>components-multiple-runtime-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<artifactId>components-multiple-runtime-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<artifactId>components-multiple-runtime-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<artifactId>components-multiple-runtime-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<artifactId>components-multiple-runtime-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<artifactId>same_libs_with_2_versions</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<artifactId>same_libs_with_2_versions</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<artifactId>same_libs_with_2_versions</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<artifactId>same_libs_with_2_versions</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<artifactId>same_libs_with_2_versions</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLib</artifactId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<name>zeLib V1</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLib</artifactId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<name>zeLib V1</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLib</artifactId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<name>zeLib V1</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLib</artifactId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<name>zeLib V1</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLib</artifactId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<name>zeLib V1</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLibV2</artifactId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<name>zeLib V2</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLibV2</artifactId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<name>zeLib V2</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLibV2</artifactId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<name>zeLib V2</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLibV2</artifactId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<name>zeLib V2</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.test</groupId>
 	<artifactId>zeLibV2</artifactId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<name>zeLib V2</name>
 	
 	<properties>

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../../components-parent/pom.xml</relativePath>             
     </parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<artifactId>components-examples-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<artifactId>components-examples-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<artifactId>components-examples-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<artifactId>components-examples-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<artifactId>components-examples-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
     <artifactId>components</artifactId>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
     <artifactId>components</artifactId>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.talend.components</groupId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
     <artifactId>components</artifactId>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
     <artifactId>components</artifactId>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
     <artifactId>components</artifactId>
     <packaging>pom</packaging>
 

--- a/services/components-api-service-common/pom.xml
+++ b/services/components-api-service-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-common/pom.xml
+++ b/services/components-api-service-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-common/pom.xml
+++ b/services/components-api-service-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-common/pom.xml
+++ b/services/components-api-service-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-common/pom.xml
+++ b/services/components-api-service-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-osgi/pom.xml
+++ b/services/components-api-service-osgi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-osgi/pom.xml
+++ b/services/components-api-service-osgi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-osgi/pom.xml
+++ b/services/components-api-service-osgi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-osgi/pom.xml
+++ b/services/components-api-service-osgi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-osgi/pom.xml
+++ b/services/components-api-service-osgi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <artifactId>components-api-service-rest-all-components</artifactId>
 

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <artifactId>components-api-service-rest-all-components</artifactId>
 

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <artifactId>components-api-service-rest-all-components</artifactId>
 

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.talend.components</groupId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <artifactId>components-api-service-rest-all-components</artifactId>
 

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.talend.components</groupId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <artifactId>components-api-service-rest-all-components</artifactId>
 
@@ -23,7 +23,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <daikon.version>0.23.0-SNAPSHOT</daikon.version>
+        <daikon.version>0.23.0</daikon.version>
         <!-- Used for Docker images name -->
         <git_branch>local</git_branch>
         <docker_tag_suffix>${maven.build.timestamp}</docker_tag_suffix>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-api-service-rest</artifactId>
-    <version>0.23.2-SNAPSHOT</version>
+    <version>0.23.2</version>
 
     <name>Component REST API</name>
     <properties>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>service-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.0</version>
         <relativePath></relativePath>
     </parent>
 

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>service-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-api-service-rest</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.23.1-SNAPSHOT</version>
 
     <name>Component REST API</name>
     <properties>
@@ -20,7 +20,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <daikon.version>0.23.0-SNAPSHOT</daikon.version>
+        <daikon.version>0.23.0</daikon.version>
         <!-- Used for Docker images name -->
         <git_branch>local</git_branch>
         <docker_tag_suffix>${maven.build.timestamp}</docker_tag_suffix>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-api-service-rest</artifactId>
-    <version>0.23.2</version>
+    <version>0.23.3-SNAPSHOT</version>
 
     <name>Component REST API</name>
     <properties>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-api-service-rest</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
 
     <name>Component REST API</name>
     <properties>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>service-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath></relativePath>
     </parent>
 
     <groupId>org.talend.components</groupId>
     <artifactId>components-api-service-rest</artifactId>
-    <version>0.23.1-SNAPSHOT</version>
+    <version>0.23.1</version>
 
     <name>Component REST API</name>
     <properties>

--- a/services/components-api-service-spi-test/pom.xml
+++ b/services/components-api-service-spi-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-spi-test/pom.xml
+++ b/services/components-api-service-spi-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-spi-test/pom.xml
+++ b/services/components-api-service-spi-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-spi-test/pom.xml
+++ b/services/components-api-service-spi-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-spi-test/pom.xml
+++ b/services/components-api-service-spi-test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-api-service-spi/pom.xml
+++ b/services/components-api-service-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.22.0-SNAPSHOT</version>
+        <version>0.23.1-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-spi/pom.xml
+++ b/services/components-api-service-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2-SNAPSHOT</version>
+        <version>0.23.2</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-spi/pom.xml
+++ b/services/components-api-service-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.2</version>
+        <version>0.23.3-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-spi/pom.xml
+++ b/services/components-api-service-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-api-service-spi/pom.xml
+++ b/services/components-api-service-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>components-parent</artifactId>
-        <version>0.23.1-SNAPSHOT</version>
+        <version>0.23.1</version>
         <relativePath>../../components-parent/pom.xml</relativePath>
     </parent>
 

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1</version>
+		<version>0.23.2-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.1-SNAPSHOT</version>
+		<version>0.23.1</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2-SNAPSHOT</version>
+		<version>0.23.2</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.23.2</version>
+		<version>0.23.3-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/components-maven-repo/pom.xml
+++ b/services/components-maven-repo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.talend.components</groupId>
 		<artifactId>components-parent</artifactId>
-		<version>0.22.0-SNAPSHOT</version>
+		<version>0.23.1-SNAPSHOT</version>
 		<relativePath>../../components-parent/pom.xml</relativePath>
 	</parent>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.23.1-SNAPSHOT</version>
 	<artifactId>components-api-service-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1-SNAPSHOT</version>
+	<version>0.23.1</version>
 	<artifactId>components-api-service-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2</version>
+	<version>0.23.3-SNAPSHOT</version>
 	<artifactId>components-api-service-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.1</version>
+	<version>0.23.2-SNAPSHOT</version>
 	<artifactId>components-api-service-aggregator</artifactId>
 	<packaging>pom</packaging>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.talend.components</groupId>
-	<version>0.23.2-SNAPSHOT</version>
+	<version>0.23.2</version>
 	<artifactId>components-api-service-aggregator</artifactId>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40793

Hive jdbc setRadOnly JDBC method throws SQLException and we only catch SQLFeatureNotSupportedException on that call.

**What is the new behavior?**
We catch SQLException 

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Don't know if there is breaking change.