### PR TITLE
fix(TDI-40793) : Catch SQLException on jdbc setReadOnly call

### DIFF
--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
@@ -195,7 +195,7 @@ public class JdbcRuntimeUtils {
             if (readonly) {
                 try {
                     conn.setReadOnly(setting.isReadOnly());
-                } catch (SQLFeatureNotSupportedException e) {
+                } catch (SQLException e) {
                     LOGGER.debug("JDBC driver '{}' does not support read only mode.", setting.getDriverClass(), e);
                 }
             }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40793

Hive jdbc setRadOnly JDBC method throws SQLException and we only catch SQLFeatureNotSupportedException on that call.


**What is the new behavior?**
We catch SQLException 



**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Don't know if there is breaking change.