### PR TITLE
chore(AVPath): cache the AVPath parser.

### DIFF
--- a/components/components-processing/processing-runtime/pom.xml
+++ b/components/components-processing/processing-runtime/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.wandoulabs.avro</groupId>
             <artifactId>wandou-avpath_2.11</artifactId>
-            <version>0.1.3-talend</version>
+            <version>0.1.3-talend-SNAPSHOT</version>
         </dependency>
 
         <!-- necessary for Spark unit tests -->

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFnTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFnTest.java
@@ -309,7 +309,7 @@ public class FieldSelectorDoFnTest {
         assertEquals(0, outputs.size());
     }
 
-    @Test(expected = TalendRuntimeException.class)
+    @Test(expected = wandou.avpath.Parser.AvroPathException.class)
     public void testHierarchicalSyntaxError() throws Exception {
         FieldSelectorProperties properties = addSelector(null, "id", "asdf&*{.\\\\t");
 

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtilTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtilTest.java
@@ -27,6 +27,8 @@ import org.talend.components.processing.runtime.SampleAvpathSchemas;
 import org.talend.daikon.exception.TalendRuntimeException;
 
 import wandou.avpath.Evaluator;
+import wandou.avpath.Parser;
+import wandou.avpath.Parser.PathSyntax;
 
 public class FieldSelectorUtilTest {
 
@@ -111,37 +113,26 @@ public class FieldSelectorUtilTest {
 
     @Test
     public void testGetInputFields() throws Exception {
-        assertEquals(0, FieldSelectorUtil.getInputFields(inputHierarchical, "NOTHING").size());
-
-        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, "id").get(0).value());
-        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, ".{.id == 1}.id").get(0).value());
-        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, ".id").get(0).value());
-        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, "a1.id").get(0).value());
-        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, ".a1.id").get(0).value());
-        assertEquals(5, (int) FieldSelectorUtil.getInputFields(inputHierarchical, "a1.a2.id").get(0).value());
-        assertEquals(5, (int) FieldSelectorUtil.getInputFields(inputHierarchical, ".a1.a2.id").get(0).value());
+        assertEquals(0, FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".NOTHING")).size());
+        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".{.id == 1}.id")).get(0).value());
+        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".id")).get(0).value());
+        assertEquals(1, (int) FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".a1.id")).get(0).value());
+        assertEquals(5, (int) FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".a1.a2.id")).get(0).value());
         assertEquals("Q2G5V64PQQ",
-                (String) FieldSelectorUtil.getInputFields(inputHierarchical, "a1.a2.name").get(0).value());
-        assertEquals("Q2G5V64PQQ",
-                (String) FieldSelectorUtil.getInputFields(inputHierarchical, ".a1.a2.name").get(0).value());
-    }
-
-    @Test(expected = TalendRuntimeException.class)
-    public void testGetInputFieldsInvalid() throws TalendRuntimeException {
-        FieldSelectorUtil.getInputFields(inputHierarchical, "NOPµf,sgldsf**///E");
+                (String) FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".a1.a2.name")).get(0).value());
     }
 
     @Test
     public void testExtractValuesFromContextSimpleValue() throws Exception {
 
-        List<Evaluator.Ctx> ctxList = FieldSelectorUtil.getInputFields(inputHierarchical, "id");
-        Object id = FieldSelectorUtil.extractValuesFromContext(ctxList, "id");
+        List<Evaluator.Ctx> ctxList = FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".id"));
+        Object id = FieldSelectorUtil.extractValuesFromContext(ctxList, ".id");
         assertEquals(1, (int) id);
     }
     
     @Test
     public void testExtractValuesFromContextList() throws Exception {
-        List<Evaluator.Ctx> ctxList = FieldSelectorUtil.getInputFields(inputHierarchical, ".a1{.id == 1}.id");
+        List<Evaluator.Ctx> ctxList = FieldSelectorUtil.getInputFields(inputHierarchical, new Parser().parse(".a1{.id == 1}.id"));
         List<Object> idList = (List<Object>) FieldSelectorUtil.extractValuesFromContext(ctxList, ".a1{.id == 1}.id");
         assertEquals(1, idList.size());
         assertEquals(1, (int) idList.get(0));


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
The AVPath currently does not cache the AST to reach an element. As a result, we compute it to every single element.


**What is the new behavior?**
Cache the AST.
Linked to https://github.com/Talend/avpath/pull/1


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features) ?
- [X] The code coverage on new code >75%
- [X] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
