### PR TITLE
[WIP][TCOMP-1141] upgrading dependencies (spring boot/spring, jackson and jetty

### DIFF
--- a/components-parent/components-bom/pom.xml
+++ b/components-parent/components-bom/pom.xml
@@ -35,7 +35,7 @@
         <bnd-annotation.version>2.4.0</bnd-annotation.version>
         <calcite.version>1.16.0</calcite.version>
         <com.fasterxml.classmate.version>1.3.3</com.fasterxml.classmate.version>
-        <com.fasterxml.jackson.version>2.8.8</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.9.7</com.fasterxml.jackson.version>
         <com.google.http-client.version>1.23.0</com.google.http-client.version>
         <com.google.oauth-client.version>1.23.0</com.google.oauth-client.version>
         <com.yahoo.datasketches.memory.version>${com.yahoo.datasketches.version}</com.yahoo.datasketches.memory.version>
@@ -106,7 +106,7 @@
         <jackson-xc.version>1.9.13</jackson-xc.version>
         <jackson.1x.version>1.9.14-TALEND</jackson.1x.version>
         <jackson.version.annotations>2.9.0</jackson.version.annotations>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <javacsv.version>2.0</javacsv.version>
         <javapoet.version>1.8.0</javapoet.version>
         <javax.activation.version>1.1.1</javax.activation.version>
@@ -124,7 +124,7 @@
         <jersey-server.version>1.9</jersey-server.version>
         <jersey-test-framework-core.version>1.9</jersey-test-framework-core.version>
         <jersey-test-framework-grizzly2.version>1.9</jersey-test-framework-grizzly2.version>
-        <jetty.version>9.4.1.v20170120</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <jline.version>2.12</jline.version>
         <jmespath-java.version>${aws.version}</jmespath-java.version>
         <joda-time.version>2.8.2</joda-time.version>
@@ -171,11 +171,11 @@
         <snappy-java.version>1.1.1.3</snappy-java.version>
         <snowflake-jdbc.version>3.6.13</snowflake-jdbc.version>
         <spark.version>2.2.1</spark.version>
-        <spring-boot.version>1.5.1.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.17.RELEASE</spring-boot.version>
         <spring-retry.version>1.2.0.RELEASE</spring-retry.version>
         <spring-security-crypto.version>4.2.1.RELEASE</spring-security-crypto.version>
         <spring-security-rsa.version>1.0.3.RELEASE</spring-security-rsa.version>
-        <spring-test.version>4.3.3.RELEASE</spring-test.version>
+        <spring-test.version>4.3.20.RELEASE</spring-test.version>
         <stax2-api.version>4.1</stax2-api.version>
         <talend_file_enhanced_20070724.version>6.0.0</talend_file_enhanced_20070724.version>
         <talendcsv.version>6.0.0</talendcsv.version>
@@ -1033,12 +1033,6 @@
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${spring-test.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot</artifactId>
                 <version>${spring-boot.version}</version>
@@ -1053,6 +1047,26 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-jetty</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-test.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring-test.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring-test.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.17.RELEASE</version>
     </parent>
 
     <groupId>org.talend.components</groupId>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -22,7 +22,9 @@
         <!-- Used for Docker images name -->
         <git_branch>local</git_branch>
         <talend_docker_registry>registry.datapwn.com</talend_docker_registry>
-
+        <spring-boot.version>1.5.17.RELEASE</spring-boot.version> <!-- this pom hierarchy is really broken -->
+        <spring.version>4.3.20.RELEASE</spring.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <biz.aQute.bnd.annotation.version>2.4.0</biz.aQute.bnd.annotation.version>
         <commons-io.version>2.5</commons-io.version>
         <derby.version>10.12.1.1</derby.version>
@@ -33,7 +35,7 @@
         <httpcore-nio.version>4.4.5</httpcore-nio.version>
         <httpcore.version>4.4.9</httpcore.version>
         <jackson.version.annotations>2.9.0</jackson.version.annotations>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <org.talend.libraries.mysql.version>6.0.0</org.talend.libraries.mysql.version>
         <pax-url-aethe.version>2.4.7</pax-url-aethe.version>
         <rest-assured.version>2.6.0</rest-assured.version>
@@ -52,10 +54,22 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jetty</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -71,10 +85,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <!-- talend dependencies -->
@@ -120,6 +130,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -218,6 +229,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

spring boot, jackson and jetty are outdated


**What is the new behavior?**

versoin are up to date

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

1. depends on https://jira.talendforge.org/browse/TCOMP-1141 and Pierre's feedback to ensure we can upgrade
2. the upgrade is dirty due to the pom setup (bom+parent which is likely an error), no common parent etc and it is ok in the scope of this task
