### PR TITLE
fix(TDI-42740): tNetsuiteInput throws cast error when switching from …

### DIFF
--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionProperties.java
@@ -33,6 +33,7 @@ import org.talend.components.netsuite.NetSuiteComponentDefinition;
 import org.talend.components.netsuite.NetSuiteProvideConnectionProperties;
 import org.talend.components.netsuite.NetSuiteRuntime;
 import org.talend.components.netsuite.NetSuiteVersion;
+import org.talend.components.netsuite.input.NetSuiteInputProperties;
 import org.talend.daikon.java8.Function;
 import org.talend.daikon.properties.PresentationItem;
 import org.talend.daikon.properties.ValidationResult;
@@ -217,7 +218,14 @@ public class NetSuiteConnectionProperties extends ComponentPropertiesImpl
      * @return referenced connection properties or {@code null}
      */
     public NetSuiteConnectionProperties getReferencedConnectionProperties() {
-        NetSuiteConnectionProperties refProps = referencedComponent.getReference();
+        NetSuiteConnectionProperties refProps;
+        Object obj = referencedComponent.getReference();
+        if (obj instanceof NetSuiteInputProperties) {
+            refProps = ((NetSuiteInputProperties) obj).connection;
+        } else {
+            refProps = (NetSuiteConnectionProperties) obj;
+        }
+
         if (refProps != null) {
             return refProps;
         }
@@ -269,7 +277,7 @@ public class NetSuiteConnectionProperties extends ComponentPropertiesImpl
     public NetSuiteRuntime.Context getDesignTimeContext() {
         // If the component refers to another component
         // then we should use design-time context from referenced connection properties.
-        NetSuiteConnectionProperties refProps = referencedComponent.getReference();
+        NetSuiteConnectionProperties refProps = getReferencedConnectionProperties();
         if (refProps != null) {
             return refProps.getDesignTimeContext();
         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
class cast exception (NetSuiteInputProperties to NetSuiteConnectionProperties)

**What is the new behavior?**
process correctly class cast

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TDI-42740