### PR TITLE
fix(TDI-43612): Handling underscores in Snowflake objects names

### DIFF
--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistry.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistry.java
@@ -12,9 +12,11 @@
 // ============================================================================
 package org.talend.components.snowflake.runtime;
 
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Set;
 
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -209,4 +211,15 @@ public class SnowflakeAvroRegistry extends JDBCAvroRegistry {
             }
         };
     }
+
+    private  String removeEscapes(String value) {
+        return value.replace("\\_", "_");
+    }
+
+    @Override
+    protected Set<String> getPrimaryKeys(DatabaseMetaData databaseMetdata, String catalogName, String schemaName, String tableName)
+            throws SQLException {
+        return super.getPrimaryKeys(databaseMetdata, catalogName, removeEscapes(schemaName), removeEscapes(tableName));
+    }
+
 }

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSink.java
@@ -243,7 +243,7 @@ public class SnowflakeSourceOrSink extends SnowflakeRuntime implements SourceOrS
         try {
             JDBCTableMetadata tableMetadata = new JDBCTableMetadata();
             tableMetadata.setDatabaseMetaData(connection.getMetaData()).setCatalog(getCatalog(connProps))
-                    .setDbSchema(getDbSchema(connProps)).setTablename(tableName);
+                    .setDbSchema(escapeUnderscores(getDbSchema(connProps))).setTablename(escapeUnderscores(tableName));
             tableSchema = getSnowflakeAvroRegistry().inferSchema(tableMetadata);
             if (tableSchema == null) {
                 throw new IOException(i18nMessages.getMessage("error.tableNotFound", tableName));
@@ -254,6 +254,10 @@ public class SnowflakeSourceOrSink extends SnowflakeRuntime implements SourceOrS
 
         return tableSchema;
 
+    }
+
+    private String escapeUnderscores(String value) {
+        return value.replace("_", "\\_");
     }
 
     @Override

--- a/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistry.java
+++ b/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistry.java
@@ -144,7 +144,7 @@ public class JDBCAvroRegistry extends AvroRegistry {
         }
     }
 
-    private Set<String> getPrimaryKeys(DatabaseMetaData databaseMetdata, String catalogName, String schemaName, String tableName)
+    protected Set<String> getPrimaryKeys(DatabaseMetaData databaseMetdata, String catalogName, String schemaName, String tableName)
             throws SQLException {
         Set<String> result = new HashSet<>();
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-43612

**What is the new behavior?**

Added functionality that escapes the underscores and remove escapes before underscores in object names. Now tables and schemas that have the symbol "_" in their names can be obtained from Snowflake.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
