### PR TITLE
chore(codebase): mvn plugin formatter for codestyle and copyrights

### DIFF
--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -45,6 +45,8 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <cxf.version>3.3.4</cxf.version>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
     </properties>
 
@@ -203,7 +205,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -45,6 +45,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <cxf.version>3.3.4</cxf.version>
+        <spotless.version>1.24.0</spotless.version>
     </properties>
 
     <scm>
@@ -184,6 +185,49 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/components-parent/pom.xml
+++ b/components-parent/pom.xml
@@ -204,18 +204,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -67,18 +67,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <spotless.version>1.24.0</spotless.version>
         <!-- skip the deployment for this aggregator, not necessary -->
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -39,4 +40,57 @@
         <module>components-snowflake</module>
         <module>components-couchbase</module>
     </modules>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>releases</id>
+            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -10,6 +10,8 @@
     <packaging>pom</packaging>
 
     <properties>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
         <!-- skip the deployment for this aggregator, not necessary -->
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -66,7 +68,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,6 +9,8 @@
     <packaging>pom</packaging>
 
     <properties>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
         <!-- skip the deployment for this aggregator, not necessary -->
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -49,7 +51,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,6 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <spotless.version>1.24.0</spotless.version>
         <!-- skip the deployment for this aggregator, not necessary -->
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -21,5 +22,58 @@
         <module>components-osgi-test</module>
         <module>components-common</module>
         <module>components-common-oauth</module>
-  </modules>
+    </modules>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>releases</id>
+            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,18 +50,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,6 +10,8 @@
 	<name>Components examples Aggregator</name>
 
 	<properties>
+		<timestamp.year>${maven.build.timestamp}</timestamp.year>
+		<maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
 		<spotless.version>1.24.0</spotless.version>
 	</properties>
 
@@ -45,7 +47,7 @@
 						<encoding>UTF-8</encoding>
 						<licenseHeader>
 							<content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,18 +46,18 @@
 					<java>
 						<encoding>UTF-8</encoding>
 						<licenseHeader>
-							<content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+							<content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
 						</licenseHeader>
 						<eclipse>
 							<file>talend_java_eclipse_formatter.xml</file>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,14 +8,68 @@
 	<packaging>pom</packaging>
 
 	<name>Components examples Aggregator</name>
+
+	<properties>
+		<spotless.version>1.24.0</spotless.version>
+	</properties>
+
 	<modules>
 		<module>components-multiple-runtimes-and-deps</module>
 		<module>components-api-archetypes</module>
 		<module>components-api-full-example</module>
 	</modules>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>releases</id>
+			<url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+		</pluginRepository>
+	</pluginRepositories>
 	<build>
 		<!-- skip the deployment for this aggregator, not necessary -->
 		<plugins>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>${spotless.version}</version>
+				<executions>
+					<execution>
+						<id>apply</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>apply</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<java>
+						<encoding>UTF-8</encoding>
+						<licenseHeader>
+							<content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+						</licenseHeader>
+						<eclipse>
+							<file>talend_java_eclipse_formatter.xml</file>
+						</eclipse>
+					</java>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.talend.tools</groupId>
+						<artifactId>java-formatter</artifactId>
+						<version>0.1.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,18 +82,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
         <talend.releases.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</talend.releases.repo>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
     </properties>
 
@@ -81,7 +83,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
         <talend.releases.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</talend.releases.repo>
+        <spotless.version>1.24.0</spotless.version>
     </properties>
 
     <scm>
@@ -39,6 +40,12 @@
         <module>components</module>
         <module>services</module>
     </modules>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>releases</id>
+            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <plugins>
             <plugin>
@@ -56,6 +63,49 @@
 					      <autoVersionSubmodules>true</autoVersionSubmodules>
 				      </configuration>
 			      </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -23,6 +23,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spotless.version>1.24.0</spotless.version>
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
         <talend.releases.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</talend.releases.repo>
@@ -219,6 +220,49 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -239,18 +239,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/services/components-api-service-rest-all-components/pom.xml
+++ b/services/components-api-service-rest-all-components/pom.xml
@@ -23,6 +23,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
@@ -238,7 +240,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -19,7 +19,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-
+        <spotless.version>1.24.0</spotless.version>
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
         <talend.releases.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</talend.releases.repo>
@@ -334,9 +334,57 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <pluginRepositories>
+        <pluginRepository>
+            <id>releases</id>
+            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <!-- To get the GIT information for version endpoint. -->
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -19,6 +19,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <timestamp.year>${maven.build.timestamp}</timestamp.year>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <spotless.version>1.24.0</spotless.version>
         <!-- repositories -->
         <talend.snapshots.repo>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend.snapshots.repo>
@@ -360,7 +362,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/services/components-api-service-rest/pom.xml
+++ b/services/components-api-service-rest/pom.xml
@@ -361,18 +361,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -50,7 +50,7 @@
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
                             <content><![CDATA[/*
- * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -9,6 +9,11 @@
     <packaging>pom</packaging>
 
     <name>Component Services Aggregator</name>
+
+    <properties>
+        <spotless.version>1.24.0</spotless.version>
+    </properties>
+
     <modules>
         <module>components-api-service-common</module>
         <module>components-api-service-osgi</module>
@@ -18,9 +23,58 @@
         <module>components-api-service-spi-test</module>
         <module>components-maven-repo</module>
     </modules>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>releases</id>
+            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <!-- skip the deployment for this aggregator, not necessary -->
         <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <id>apply</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <encoding>UTF-8</encoding>
+                        <licenseHeader>
+                            <content><![CDATA[/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+*/]]></content>
+                        </licenseHeader>
+                        <eclipse>
+                            <file>talend_java_eclipse_formatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.talend.tools</groupId>
+                        <artifactId>java-formatter</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -49,18 +49,18 @@
                     <java>
                         <encoding>UTF-8</encoding>
                         <licenseHeader>
-                            <content><![CDATA[/*
- * Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
-*/]]></content>
+                            <content><![CDATA[// ============================================================================
+//
+// Copyright (C) 2006-${timestamp.year} Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================]]></content>
                         </licenseHeader>
                         <eclipse>
                             <file>talend_java_eclipse_formatter.xml</file>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Add maven plugin like in connectors-se repository to maintain codestyle and copyrights

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
