### PR TITLE
chore: update copyright to 2020

### DIFF
--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnection.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnectionWithKeyService.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnectionWithKeyService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnectionWithSasService.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureConnectionWithSasService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageFamilyDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageProvideConnectionProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/AzureStorageProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobService.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageBlobService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageContainerDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageContainerDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageContainerProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/AzureStorageContainerProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/FileMaskTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/FileMaskTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlob.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlob.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobGet.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobGet.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobsGetTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobsGetTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobsTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/helpers/RemoteBlobsTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerDeleteRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerDeleteRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerExistRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerExistRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerListReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerListReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageDeleteRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageDeleteRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageGetRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageGetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageListReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageListReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStoragePutRuntime.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStoragePutRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSource.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSourceOrSink.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainercreate/TAzureStorageContainerCreateDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainercreate/TAzureStorageContainerCreateDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainercreate/TAzureStorageContainerCreateProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainercreate/TAzureStorageContainerCreateProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerdelete/TAzureStorageContainerDeleteDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerdelete/TAzureStorageContainerDeleteDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerdelete/TAzureStorageContainerDeleteProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerdelete/TAzureStorageContainerDeleteProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerexist/TAzureStorageContainerExistDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerexist/TAzureStorageContainerExistDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerexist/TAzureStorageContainerExistProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerexist/TAzureStorageContainerExistProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerlist/TAzureStorageContainerListDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerlist/TAzureStorageContainerListDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerlist/TAzureStorageContainerListProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragecontainerlist/TAzureStorageContainerListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragedelete/TAzureStorageDeleteDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragedelete/TAzureStorageDeleteDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragedelete/TAzureStorageDeleteProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragedelete/TAzureStorageDeleteProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageget/TAzureStorageGetDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageget/TAzureStorageGetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageget/TAzureStorageGetProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageget/TAzureStorageGetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragelist/TAzureStorageListDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragelist/TAzureStorageListDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragelist/TAzureStorageListProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestoragelist/TAzureStorageListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageput/TAzureStoragePutDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageput/TAzureStoragePutDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageput/TAzureStoragePutProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/blob/tazurestorageput/TAzureStoragePutProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueService.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/AzureStorageQueueService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputLoopReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputLoopReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueListReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueListReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSink.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSource.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceOrSink.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriteOperation.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriter.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/QueueMessage.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/runtime/QueueMessage.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuecreate/TAzureStorageQueueCreateDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuecreate/TAzureStorageQueueCreateDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuecreate/TAzureStorageQueueCreateProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuecreate/TAzureStorageQueueCreateProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuedelete/TAzureStorageQueueDeleteDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuedelete/TAzureStorageQueueDeleteDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuedelete/TAzureStorageQueueDeleteProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuedelete/TAzureStorageQueueDeleteProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinput/TAzureStorageQueueInputDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinput/TAzureStorageQueueInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinput/TAzureStorageQueueInputProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinput/TAzureStorageQueueInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinputloop/TAzureStorageQueueInputLoopDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinputloop/TAzureStorageQueueInputLoopDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinputloop/TAzureStorageQueueInputLoopProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueinputloop/TAzureStorageQueueInputLoopProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuelist/TAzureStorageQueueListDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuelist/TAzureStorageQueueListDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuelist/TAzureStorageQueueListProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuelist/TAzureStorageQueueListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueoutput/TAzureStorageQueueOutputDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueoutput/TAzureStorageQueueOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueoutput/TAzureStorageQueueOutputProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeueoutput/TAzureStorageQueueOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuepurge/TAzureStorageQueuePurgeDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuepurge/TAzureStorageQueuePurgeDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuepurge/TAzureStorageQueuePurgeProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/queue/tazurestoragequeuepurge/TAzureStorageQueuePurgeProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableService.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/AzureStorageTableService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageAvroRegistry.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageDTEConverterFactory.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageDTEConverterFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageDTEConverters.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageDTEConverters.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageTableAdaptorFactory.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/avro/AzureStorageTableAdaptorFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Comparison.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Comparison.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/NameMappingTable.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/NameMappingTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Predicate.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/Predicate.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/SupportedFieldType.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/helpers/SupportedFieldType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableReader.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSink.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSource.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.comç
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.comç
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSourceOrSink.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriteOperation.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageinputtable/TAzureStorageInputTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageoutputtable/TAzureStorageOutputTableDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageoutputtable/TAzureStorageOutputTableDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageoutputtable/TAzureStorageOutputTableProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/table/tazurestorageoutputtable/TAzureStorageOutputTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/utils/AzureStorageUtils.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/utils/AzureStorageUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/utils/SharedAccessSignatureUtils.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/utils/SharedAccessSignatureUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListProperties.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionEditWizardDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizard.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardDefinition.java
+++ b/components/components-azurestorage/src/main/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureBaseTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureBaseTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureConnectionWithKeyServiceTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureConnectionWithKeyServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureConnectionWithSasServiceTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureConnectionWithSasServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageBaseTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageBaseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageComponentsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageComponentsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageGenericBase.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/AzureStorageGenericBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/FileUtils.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/FileUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/RuntimeContainerMock.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/RuntimeContainerMock.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/SpringAzureStorageGenericIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/SpringAzureStorageGenericIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/TAzureStorageConnectionTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/TAzureStorageConnectionTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/AzureStorageContainerDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/AzureStorageContainerDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerCreateDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerCreateDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerDeleteDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerDeleteDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerExistDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerExistDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerListDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageContainerListDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageDeleteDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageDeleteDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageGetDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageGetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageListDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStorageListDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStoragePutDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/TAzureStoragePutDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/helpers/FileMaskTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/helpers/FileMaskTableTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/helpers/RemoteBlobTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/definitions/helpers/RemoteBlobTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerCreateRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerCreateRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerDeleteRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerDeleteRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerExistRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerExistRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerListReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageContainerListReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageDeleteRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageDeleteRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageGetRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageGetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageListReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageListReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStoragePutRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStoragePutRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSourceTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/AzureStorageSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/DummyCloudBlobContainerIterator.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/DummyCloudBlobContainerIterator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/DummyListBlobItemIterator.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/DummyListBlobItemIterator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageBaseBlobTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageBaseBlobTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerDeleteReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerDeleteReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerExistReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerExistReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerListReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageContainerListReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageDeleteReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageDeleteReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageGetReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageGetReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageListReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageListReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStoragePutReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStoragePutReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageSourceOrSinkTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/blob/runtime/it/AzureStorageSourceOrSinkTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/AzureStorageQueueComponentsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/AzureStorageQueueComponentsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueCreateRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueCreateRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueDeleteRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueDeleteRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputLoopReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputLoopReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueInputReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueListReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueListReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueuePurgeRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueuePurgeRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueRuntimeTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSinkTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceOrSinkTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriterTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/AzureStorageQueueWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/DummyCloudQueueIterator.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/DummyCloudQueueIterator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/DummyCloudQueueMessageIterator.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/DummyCloudQueueMessageIterator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageBaseQueueTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageBaseQueueTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueCreateReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueCreateReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueDeleteReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueDeleteReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueInputLoopReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueInputLoopReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueInputReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueInputReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueListReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueListReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueOutputWriterTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueueOutputWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueuePurgeReaderTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/queue/runtime/it/AzureStorageQueuePurgeReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/AzureStorageTableComponentsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/AzureStorageTableComponentsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/TableHelper.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/TableHelper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/avro/AzureStorageAvroRegistryTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/avro/AzureStorageAvroRegistryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/FilterExpressionTableTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/NameMappingTableTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/helpers/NameMappingTableTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableReaderTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSinkTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSourceOrSinkTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriteOperationTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriterTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/AzureStorageTableWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/AzureStorageTableBaseTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/AzureStorageTableBaseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/TAzureStorageInputTableTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/TAzureStorageInputTableTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/TAzureStorageOuputTableTestIT.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/table/runtime/it/TAzureStorageOuputTableTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionPropertiesTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/tazurestorageconnection/TAzureStorageConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/utils/AzureStorageUtilsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/utils/AzureStorageUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/utils/SharedAccessSignatureUtilsTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/utils/SharedAccessSignatureUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListPropertiesTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageComponentListPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionEditWizardDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionEditWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardDefinitionTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardTest.java
+++ b/components/components-azurestorage/src/test/java/org/talend/components/azurestorage/wizard/AzureStorageConnectionWizardTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryComponentFamilyDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatasetDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatasetProperties.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatastoreDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatastoreProperties.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/BigQueryDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputProperties.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/input/BigQueryInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputDefinition.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputProperties.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/output/BigQueryOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/runtime/IBigQueryDatasetRuntime.java
+++ b/components/components-bigquery/bigquery-definition/src/main/java/org/talend/components/bigquery/runtime/IBigQueryDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryComponentFamilyDefinitionTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatasetDefinitionTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatasetPropertiesTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatastoreDefinitionTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatastorePropertiesTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/BigQueryDatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/input/BigQueryInputDefinitionTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/input/BigQueryInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/input/BigQueryInputPropertiesTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/input/BigQueryInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputDefinitionTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputPropertiesTest.java
+++ b/components/components-bigquery/bigquery-definition/src/test/java/org/talend/components/bigquery/output/BigQueryOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/BigQueryComponentFamilyDefinitionTest.java
+++ b/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/BigQueryComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/BigQueryDatasetTestIT.java
+++ b/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/BigQueryDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/DisableIfMissingConfig.java
+++ b/components/components-bigquery/bigquery-integration/src/test/java/org/talend/components/bigquery/integration/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryAvroRegistry.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryBaseIndexedRecordConverter.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryBaseIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryConnection.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryDatasetRuntime.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryDatastoreRuntime.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryInputRuntime.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryOutputRuntime.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryTableRowIndexedRecordConverter.java
+++ b/components/components-bigquery/bigquery-runtime/src/main/java/org/talend/components/bigquery/runtime/BigQueryTableRowIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryAvroRegistryTest.java
+++ b/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryAvroRegistryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryBeamRuntimeTestIT.java
+++ b/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryBeamRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryTestConstants.java
+++ b/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/BigQueryTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/DisableIfMissingConfig.java
+++ b/components/components-bigquery/bigquery-runtime/src/test/java/org/talend/components/bigquery/runtime/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-couchbase/src/test/java/org/talend/components/couchbase/DisablablePaxExam.java
+++ b/components/components-couchbase/src/test/java/org/talend/components/couchbase/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-couchbase/src/test/java/org/talend/components/couchbase/RequiresCouchbaseServer.java
+++ b/components/components-couchbase/src/test/java/org/talend/components/couchbase/RequiresCouchbaseServer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchComponentFamilyDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatasetDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatasetProperties.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatastoreDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatastoreProperties.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/ElasticsearchDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputProperties.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/input/ElasticsearchInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinition.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputProperties.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/main/java/org/talend/components/elasticsearch/output/ElasticsearchOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchComponentFamilyDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatasetDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatasetPropertiesTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatastoreDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatastorePropertiesTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/ElasticsearchDatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/input/ElasticsearchInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/input/ElasticsearchInputPropertiesTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/input/ElasticsearchInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/output/ElasticsearchOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/output/ElasticsearchOutputPropertiesTest.java
+++ b/components/components-elasticsearch/elasticsearch-definition/src/test/java/org/talend/components/elasticsearch/output/ElasticsearchOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-integration/src/test/java/org/talend/components/elasticsearch/integration/ElasticsearchComponentFamilyDefinitionTest.java
+++ b/components/components-elasticsearch/elasticsearch-integration/src/test/java/org/talend/components/elasticsearch/integration/ElasticsearchComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-integration/src/test/java/org/talend/components/elasticsearch/integration/ElasticsearchDatastoreTestIT.java
+++ b/components/components-elasticsearch/elasticsearch-integration/src/test/java/org/talend/components/elasticsearch/integration/ElasticsearchDatastoreTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchConnection.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchDatasetRuntime.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchDatastoreRuntime.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchInputRuntime.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchOutputRuntime.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchResponse.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/main/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchResponse.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchBeamRuntimeTestIT.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchBeamRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchTestConstants.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchTestUtils.java
+++ b/components/components-elasticsearch/elasticsearch-runtime_2_4/src/test/java/org/talend/components/elasticsearch/runtime_2_4/ElasticsearchTestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/DecodeTable.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/DecodeTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedFamilyDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedProperties.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/FileDelimitedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedAdaptorFactory.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedAdaptorFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedReader.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/DelimitedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileCSVReader.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileCSVReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedAvroRegistry.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedIndexedRecordConverter.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedReader.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedSink.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedSource.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedWriteOperation.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedWriter.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileDelimitedWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileInputDelimitedRuntime.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileInputDelimitedRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileOutputDelimitedRuntime.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileOutputDelimitedRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileSourceOrSink.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/runtime/FileSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedProperties.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileinputdelimited/TFileInputDelimitedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedProperties.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/tfileoutputdelimited/TFileOutputDelimitedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FieldDelimitedEditWizardDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FieldDelimitedEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FileDelimitedWizard.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FileDelimitedWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FileDelimitedWizardDefinition.java
+++ b/components/components-filedelimited/src/main/java/org/talend/components/filedelimited/wizard/FileDelimitedWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestBasic.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestBasic.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestIT.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/FileDelimitedTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/SpringFileInputTestIT.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/SpringFileInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/runtime/FileDelimitedReaderTestIT.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/runtime/FileDelimitedReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/runtime/FileDelimitedWriterTestIT.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/runtime/FileDelimitedWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/wizard/FileDelimitedWizardTestIT.java
+++ b/components/components-filedelimited/src/test/java/org/talend/components/filedelimited/wizard/FileDelimitedWizardTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SandboxedSimpleFileIODatasetRuntimeTest.java
+++ b/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SandboxedSimpleFileIODatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SimpleFileIOComponentFamilyDefinitionTest.java
+++ b/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SimpleFileIOComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SimpleFileIODatasetRuntimeTest.java
+++ b/components/components-fileio/fileio-integration/src/test/java/org/talend/components/fileio/integration/SimpleFileIODatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
+++ b/components/components-fileio/s3-runtime-di/src/main/java/org/talend/components/s3/runtime/S3Connection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOComponentFamilyDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatasetDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatastoreDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatastoreProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIODatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOErrorCode.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2015 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOFormat.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/SimpleFileIOFormat.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/input/SimpleFileIOInputDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/input/SimpleFileIOInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/input/SimpleFileIOInputProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/input/SimpleFileIOInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatasetDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatastoreDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatastoreProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/local/LocalFileIODatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/output/SimpleFileIOOutputDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/output/SimpleFileIOOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/output/SimpleFileIOOutputProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/output/SimpleFileIOOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatastoreDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatastoreProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3DatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3Region.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/S3Region.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/input/S3InputDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/input/S3InputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/input/S3InputProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/input/S3InputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/output/S3OutputDefinition.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/output/S3OutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/output/S3OutputProperties.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/output/S3OutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/runtime/IS3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-definition/src/main/java/org/talend/components/simplefileio/s3/runtime/IS3DatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIOComponentFamilyDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIOComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatasetDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatastoreDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatastorePropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIODatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIOTestITBase.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SimpleFileIOTestITBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SpringSimpleFileIOTestIT.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/SpringSimpleFileIOTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/input/SimpleFileIOInputDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/input/SimpleFileIOInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/input/SimpleFileIOInputPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/input/SimpleFileIOInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/output/SimpleFileIOOutputDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/output/SimpleFileIOOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/output/SimpleFileIOOutputPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/output/SimpleFileIOOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatastoreDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatastorePropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3DatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3TestIT.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3TestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3TestITBase.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/S3TestITBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/input/S3InputDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/input/S3InputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/input/S3InputPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/input/S3InputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/output/S3OutputDefinitionTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/output/S3OutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/output/S3OutputPropertiesTest.java
+++ b/components/components-fileio/simplefileio-definition/src/test/java/org/talend/components/simplefileio/s3/output/S3OutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ExtraHadoopConfiguration.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ExtraHadoopConfiguration.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOAvroRegistry.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIODatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIODatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIODatastoreRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIODatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOInputRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormat.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormat.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatAvroIO.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatAvroIO.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatBase.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatCsvIO.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatCsvIO.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatExcelIO.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatExcelIO.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatParquetIO.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/SimpleRecordFormatParquetIO.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/ConfigurableHDFSFileSink.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/ConfigurableHDFSFileSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/FileParameterException.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/FileParameterException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/RelaxedHDFSFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/beamcopy/RelaxedHDFSFileSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/coders/LazyAvroKeyWrapper.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/coders/LazyAvroKeyWrapper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/ExcelUtils.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/ExcelUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/SimpleValuesContentHandler.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/SimpleValuesContentHandler.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/FilesHelper.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/FilesHelper.java
@@ -1,5 +1,5 @@
 // ============================================================================
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingReader.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingSheet.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingSheet.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingSheetReader.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingSheetReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingWorkbook.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingWorkbook.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingWorkbookReader.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/hadoop/excel/streaming/StreamingWorkbookReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3Connection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3DatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3InputRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3InputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3OutputRuntime.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/s3/S3OutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/AvroHdfsFileSink.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/AvroHdfsFileSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ConfigureWithSampleHDFSWriter.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ConfigureWithSampleHDFSWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ParquetHdfsFileSink.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/ParquetHdfsFileSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/UgiFileSinkBase.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sinks/UgiFileSinkBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/AvroHdfsFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/AvroHdfsFileSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/BoundedReaderWithLimit.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/BoundedReaderWithLimit.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/CsvHdfsFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/CsvHdfsFileSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/ExcelHdfsFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/ExcelHdfsFileSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/FileSourceBase.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/FileSourceBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/ParquetHdfsFileSource.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/ParquetHdfsFileSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/UgiFileSourceBase.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/sources/UgiFileSourceBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/ugi/UgiDoAs.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/utils/FileSystemUtil.java
+++ b/components/components-fileio/simplefileio-runtime/src/main/java/org/talend/components/simplefileio/runtime/utils/FileSystemUtil.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIODatasetRuntimeTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIODatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIODatastoreRuntimeTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIODatastoreRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOInputRuntimeTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOInputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputErrorTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputErrorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntimeTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntimeUnboundedTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIOOutputRuntimeUnboundedTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIORoundTripRuntimeTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SimpleFileIORoundTripRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SparkSimpleFileIOInputRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SparkSimpleFileIOInputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SparkSimpleFileIOOutputRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/SparkSimpleFileIOOutputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/gs/GSRoundTripRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/gs/GSRoundTripRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3DatasetRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3OutputRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3OutputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3RoundTripRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3RoundTripRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3SparkRuntimeTestIT.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3SparkRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/simplefileio/runtime/s3/S3TestResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/BeamDirectTestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/BeamDirectTestResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/DisableAfterJava8.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/DisableAfterJava8.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/DisableIfMissingConfig.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/MiniDfsResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/MiniDfsResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/MiniDfsResourceTest.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/MiniDfsResourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/RecordSet.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/RecordSet.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/RecordSetUtil.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/RecordSetUtil.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/SparkIntegrationTestResource.java
+++ b/components/components-fileio/simplefileio-runtime/src/test/java/org/talend/components/test/SparkIntegrationTestResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/ConditionsTable.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/ConditionsTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowDefinition.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowDefinition.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowFamilyDefinition.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowFamilyDefinition.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowProperties.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/TFilterRowProperties.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/EmptyFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/EmptyFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/Function.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/Function.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/FunctionType.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/FunctionType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LengthFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LengthFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LowerCaseFirstFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LowerCaseFirstFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LowerCaseFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/LowerCaseFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/MatchesFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/MatchesFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/UpperCaseFirstFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/UpperCaseFirstFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/UpperCaseFunction.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/functions/UpperCaseFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/AbstractOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/AbstractOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/EqualsOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/EqualsOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/GreaterOrEqualToOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/GreaterOrEqualToOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/GreaterThanOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/GreaterThanOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/LessThanOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/LessThanOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/LowerOrEqualToOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/LowerOrEqualToOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/NotEqualsOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/NotEqualsOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/Operator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/Operator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/OperatorType.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/operators/OperatorType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/AndValueProcessor.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/AndValueProcessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/Filter.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/Filter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/FilterDescriptor.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/FilterDescriptor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/FiltersFactory.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/FiltersFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/LogicalOperator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/LogicalOperator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/OrValueProcessor.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/OrValueProcessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ProcessingHelper.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ProcessingHelper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ProcessingResult.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ProcessingResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ValueProcessor.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/processing/ValueProcessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/FilterPrerequisitesValidator.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/FilterPrerequisitesValidator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowSink.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowWriteOperation.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowWriter.java
+++ b/components/components-filterrow/src/main/java/org/talend/components/filterrow/runtime/TFilterRowWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/DisablablePaxExam.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/OsgiTFilterRowTestIT.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/OsgiTFilterRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/SpringTFilterRowTestIT.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/SpringTFilterRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowDefinitionTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowTest.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowTestBase.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/TFilterRowTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/functions/FunctionsTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/functions/FunctionsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/operators/OperatorsTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/operators/OperatorsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/FilterPrerequisitesValidatorTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/FilterPrerequisitesValidatorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/FiltersFactoryTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/FiltersFactoryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/ValueProcessorTest.java
+++ b/components/components-filterrow/src/test/java/org/talend/components/filterrow/processing/ValueProcessorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveComponentDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveComponentProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveFamilyDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveMimeTypes.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveMimeTypes.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveProvideConnectionProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveProvideRuntime.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/GoogleDriveProvideRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/connection/GoogleDriveConnectionDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/connection/GoogleDriveConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/connection/GoogleDriveConnectionProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/connection/GoogleDriveConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/copy/GoogleDriveCopyDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/copy/GoogleDriveCopyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/copy/GoogleDriveCopyProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/copy/GoogleDriveCopyProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/create/GoogleDriveCreateDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/create/GoogleDriveCreateDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/create/GoogleDriveCreateProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/create/GoogleDriveCreateProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/delete/GoogleDriveDeleteDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/delete/GoogleDriveDeleteDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/delete/GoogleDriveDeleteProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/delete/GoogleDriveDeleteProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/get/GoogleDriveGetDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/get/GoogleDriveGetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/get/GoogleDriveGetProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/get/GoogleDriveGetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/list/GoogleDriveListDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/list/GoogleDriveListDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/list/GoogleDriveListProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/list/GoogleDriveListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/put/GoogleDrivePutDefinition.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/put/GoogleDrivePutDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/put/GoogleDrivePutProperties.java
+++ b/components/components-googledrive/components-googledrive-definition/src/main/java/org/talend/components/google/drive/put/GoogleDrivePutProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveFamilyDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveMimeTypesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveMimeTypesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveTestBase.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/GoogleDriveTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/connection/GoogleDriveConnectionDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/connection/GoogleDriveConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/connection/GoogleDriveConnectionPropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/connection/GoogleDriveConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/copy/GoogleDriveCopyDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/copy/GoogleDriveCopyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/copy/GoogleDriveCopyPropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/copy/GoogleDriveCopyPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/create/GoogleDriveCreateDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/create/GoogleDriveCreateDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/delete/GoogleDriveDeleteDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/delete/GoogleDriveDeleteDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/delete/GoogleDriveDeletePropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/delete/GoogleDriveDeletePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/get/GoogleDriveGetDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/get/GoogleDriveGetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/get/GoogleDriveGetPropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/get/GoogleDriveGetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/list/GoogleDriveListPropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/list/GoogleDriveListPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/put/GoogleDrivePutDefinitionTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/put/GoogleDrivePutDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/put/GoogleDrivePutPropertiesTest.java
+++ b/components/components-googledrive/components-googledrive-definition/src/test/java/org/talend/components/google/drive/put/GoogleDrivePutPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/DisableIfMissingConfig.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveBaseTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveBaseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveCopyTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveCopyTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveCreateDeleteTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveCreateDeleteTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveDatasetTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveListTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDriveListTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDrivePutGetTestIT.java
+++ b/components/components-googledrive/components-googledrive-integration/src/test/java/org/talend/components/google/drive/runtime/GoogleDrivePutGetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveConstants.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCopyReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCopyReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCopyRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCopyRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCreateReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCreateReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCreateRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveCreateRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveDeleteReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveDeleteReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveDeleteRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveDeleteRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveGetReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveGetReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveGetRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveGetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveListReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveListReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutWriter.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDrivePutWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveReader.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveRuntime.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSink.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSource.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSourceOrSink.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveUtils.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveValidator.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveValidator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveWriteOperation.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/GoogleDriveWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/AuthorizationCodeInstalledAppTalend.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/AuthorizationCodeInstalledAppTalend.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithAccessToken.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithAccessToken.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithInstalledApplication.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithInstalledApplication.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithServiceAccount.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithServiceAccount.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveService.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/client/GoogleDriveService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDriveGetParameters.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDriveGetParameters.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDriveGetResult.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDriveGetResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDrivePutParameters.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/main/java/org/talend/components/google/drive/runtime/utils/GoogleDrivePutParameters.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithAccessTokenTest.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithAccessTokenTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithInstalledApplicationTest.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithInstalledApplicationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithServiceAccountTest.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveCredentialWithServiceAccountTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveServiceTest.java
+++ b/components/components-googledrive/components-googledrive-runtime/src/test/java/org/talend/components/google/drive/runtime/client/GoogleDriveServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/HadoopClusterFamilyDefinition.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/HadoopClusterFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfiguration.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfiguration.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationBlackListTableProperties.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationBlackListTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputDefinition.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputProperties.java
+++ b/components/components-hadoopcluster/hadoopcluster-definition/src/main/java/org/talend/components/hadoopcluster/configuration/input/HadoopClusterConfigurationInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/com/cloudera/api/ApiObjectMapper.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/com/cloudera/api/ApiObjectMapper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/AmbariClientBuilder.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/AmbariClientBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiObjectMapper.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiObjectMapper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiRootResource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiRootResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiUtils.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/ApiUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/TextJacksonJsonProvider.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/TextJacksonJsonProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiActualConfigs.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiActualConfigs.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiActualConfigsList.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiActualConfigsList.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiCluster.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiCluster.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiClusterInfo.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiClusterInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiClusterList.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiClusterList.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiComponents.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiComponents.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFile.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFile.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFileList.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFileList.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFileList2.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigFileList2.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigList.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiConfigList.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiHostComponents.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiHostComponents.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiHostRoles.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiHostRoles.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiListBase.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiListBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiService.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiServiceInfo.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiServiceInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiServiceList.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/model/ApiServiceList.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ClusterResource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ClusterResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ClustersResource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ClustersResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ConfigsResource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ConfigsResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/RootResourceV1.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/RootResourceV1.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ServicesResource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/apache/ambari/api/v1/ServicesResource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariCluster.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariCluster.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariClusterService.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariClusterService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariConfigurator.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopAmbariConfigurator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMCluster.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMCluster.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMClusterService.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMClusterService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMConfigurator.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCMConfigurator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCluster.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopCluster.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopClusterConfigurationSourceOrSink.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopClusterConfigurationSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopClusterService.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopClusterService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopConfigurator.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopConfigurator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopHostedService.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/HadoopHostedService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/AmbariConfigurationReader.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/AmbariConfigurationReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/AmbariConfigurationSource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/AmbariConfigurationSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/ClouderaManagerConfigurationReader.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/ClouderaManagerConfigurationReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/ClouderaManagerConfigurationSource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/ClouderaManagerConfigurationSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/HadoopClusterConfigurationReader.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/HadoopClusterConfigurationReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/HadoopClusterConfigurationSource.java
+++ b/components/components-hadoopcluster/hadoopcluster-runtime/src/main/java/org/talend/components/hadoopcluster/runtime/configuration/input/HadoopClusterConfigurationSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/CommonUtils.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/CommonUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/ComponentConstants.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/ComponentConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JDBCFamilyDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JDBCFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JdbcComponentErrorsCode.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JdbcComponentErrorsCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JdbcRuntimeInfo.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/JdbcRuntimeInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/RuntimeSettingProvider.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/RuntimeSettingProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/DBType.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/DBType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataprep/JDBCInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/dataset/JDBCDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreDefinition.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastore/JDBCDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/datastream/JDBCOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/DriverTable.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/DriverTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/JDBCConnectionModule.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/JDBCConnectionModule.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/JDBCTableSelectionModule.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/JDBCTableSelectionModule.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/PreparedStatementTable.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/module/PreparedStatementTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabase4DriverClassName.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabase4DriverClassName.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabaseSchemaOrCatalogMapping.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabaseSchemaOrCatalogMapping.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabaseTypeName.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/EDatabaseTypeName.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/GenerateQueryFactory.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/GenerateQueryFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/IQueryGenerator.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/IQueryGenerator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/AS400QueryGenerator.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/AS400QueryGenerator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/DefaultQueryGenerator.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/DefaultQueryGenerator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/HiveQueryGenerator.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/HiveQueryGenerator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/NetezzaQueryGenerator.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/query/generator/NetezzaQueryGenerator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/AllSetting.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/AllSetting.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/JDBCSQLBuilder.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/JDBCSQLBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/JdbcRuntimeSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/runtime/setting/JdbcRuntimeSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcclose/TJDBCCloseDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcclose/TJDBCCloseDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcclose/TJDBCCloseProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcclose/TJDBCCloseProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbccommit/TJDBCCommitDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbccommit/TJDBCCommitDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbccommit/TJDBCCommitProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbccommit/TJDBCCommitProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcconnection/TJDBCConnectionDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcconnection/TJDBCConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcconnection/TJDBCConnectionProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcconnection/TJDBCConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcinput/TJDBCInputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcinput/TJDBCInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcinput/TJDBCInputProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcinput/TJDBCInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcoutput/TJDBCOutputDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcoutput/TJDBCOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcoutput/TJDBCOutputProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcoutput/TJDBCOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrollback/TJDBCRollbackDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrollback/TJDBCRollbackDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrollback/TJDBCRollbackProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrollback/TJDBCRollbackProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrow/TJDBCRowDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrow/TJDBCRowDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrow/TJDBCRowProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcrow/TJDBCRowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcsp/TJDBCSPDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcsp/TJDBCSPDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcsp/TJDBCSPProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/tjdbcsp/TJDBCSPProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizard.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizardDefinition.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizardProperties.java
+++ b/components/components-jdbc/components-jdbc-definition/src/main/java/org/talend/components/jdbc/wizard/JDBCConnectionWizardProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JDBCFamilyDefinitionTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JDBCFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JDBCTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JDBCTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JdbcRuntimeInfoTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/JdbcRuntimeInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatastoreTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatastoreTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataprep/JDBCInputDefinitionTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataprep/JDBCInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataset/JDBCDatasetPropertiesTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/dataset/JDBCDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/datastream/JDBCOutputDefinitionTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/datastream/JDBCOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/datastream/JDBCOutputPropertiesTest.java
+++ b/components/components-jdbc/components-jdbc-definition/src/test/java/org/talend/components/jdbc/datastream/JDBCOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/dataprep/JdbcDatasetTestIT.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/dataprep/JdbcDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/dataprep/JdbcInputTestIT.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/dataprep/JdbcInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcComponentFamilyDefinitionTest.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcDatasetRuntimeTest.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcDatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcInputOutputRuntimeTest.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcInputOutputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcRowTestIT.java
+++ b/components/components-jdbc/components-jdbc-integration/src/test/java/org/talend/components/jdbc/integration/JdbcRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime-beam/src/main/java/org/talend/components/jdbc/runtime/JDBCInputPTransformRuntime.java
+++ b/components/components-jdbc/components-jdbc-runtime-beam/src/main/java/org/talend/components/jdbc/runtime/JDBCInputPTransformRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime-beam/src/main/java/org/talend/components/jdbc/runtime/JDBCOutputPTransformRuntime.java
+++ b/components/components-jdbc/components-jdbc-runtime-beam/src/main/java/org/talend/components/jdbc/runtime/JDBCOutputPTransformRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime-beam/src/test/java/org/talend/components/jdbc/runtime/JDBCBeamRuntimeTest.java
+++ b/components/components-jdbc/components-jdbc-runtime-beam/src/test/java/org/talend/components/jdbc/runtime/JDBCBeamRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BigDecimalToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BigDecimalToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BooleanToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BooleanToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BytesToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/BytesToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/DateToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/DateToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/DoubleToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/DoubleToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/FloatToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/FloatToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/IntegerToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/IntegerToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/JDBCAvroRegistryString.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/JDBCAvroRegistryString.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/JDBCSPIndexedRecordCreator.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/JDBCSPIndexedRecordCreator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/LongToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/LongToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/ResultSetStringRecordConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/ResultSetStringRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/StringToStringConverter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/avro/StringToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/DefaultWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/DefaultWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCloseSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCloseSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCommitSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCommitSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCommitWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCCommitWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCOutputWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCOutputWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRollbackSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRollbackSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRollbackWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRollbackWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSource.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCRowWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSource.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPWriteOperation.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSPWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSource.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSourceOrSink.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JDBCSourceOrSink.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/JdbcRuntimeUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatasetRuntime.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatastoreRuntime.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/dataprep/JDBCDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCRowReader.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCRowReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCSPReader.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/reader/JDBCSPReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/type/JDBCMapping.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/type/JDBCMapping.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCCommitWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCCommitWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputDeleteWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputDeleteWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputInsertOrUpdateWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputInsertOrUpdateWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputInsertWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputInsertWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputUpdateOrInsertWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputUpdateOrInsertWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputUpdateWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputUpdateWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCOutputWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCRollbackWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCRollbackWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCRowWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCRowWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCSPWriter.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/main/java/org/talend/components/jdbc/runtime/writer/JDBCSPWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCCommitTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCCommitTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCConnectionTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCConnectionTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCInputTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCOutputTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCOutputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCRollbackTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCRollbackTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCRowTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCSPTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCSPTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCloseTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/JDBCloseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/common/DBTestUtils.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/common/DBTestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetOracleTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetOracleTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCInputTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/dataprep/JDBCInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/schema/JDBCSchemaTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/schema/JDBCSchemaTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/type/JDBCTypeMappingTestIT.java
+++ b/components/components-jdbc/components-jdbc-runtime/src/test/java/org/talend/components/jdbc/type/JDBCTypeMappingTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/Action.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/Action.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/BasicAuthenticationProperties.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/BasicAuthenticationProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/JiraConnectionProperties.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/JiraConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/JiraDefinition.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/JiraDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/JiraFamilyDefinition.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/JiraFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/JiraProperties.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/JiraProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/Mode.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/Mode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/Resource.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/Resource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/avro/IssueAdapterFactory.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/avro/IssueAdapterFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/avro/IssueIndexedRecord.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/avro/IssueIndexedRecord.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/connection/JiraResponse.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/connection/JiraResponse.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/connection/Rest.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/connection/Rest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/datum/Entity.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/datum/Entity.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/datum/EntityParser.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/datum/EntityParser.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/datum/Projects.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/datum/Projects.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/datum/Search.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/datum/Search.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSink.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSource.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSourceOrSink.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraWriteOperation.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/JiraWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraNoPaginationReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraNoPaginationReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraProjectIdReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraProjectIdReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraProjectsReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraProjectsReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraSearchReader.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/reader/JiraSearchReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraDeleteWriter.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraDeleteWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraInsertWriter.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraInsertWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraUpdateWriter.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraUpdateWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraWriter.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/runtime/writer/JiraWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/tjirainput/TJiraInputDefinition.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/tjirainput/TJiraInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/tjirainput/TJiraInputProperties.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/tjirainput/TJiraInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/tjiraoutput/TJiraOutputDefinition.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/tjiraoutput/TJiraOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/main/java/org/talend/components/jira/tjiraoutput/TJiraOutputProperties.java
+++ b/components/components-jira/src/main/java/org/talend/components/jira/tjiraoutput/TJiraOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/BasicAuthenticationPropertiesTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/BasicAuthenticationPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/DisablablePaxExam.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-jira/src/test/java/org/talend/components/jira/JiraComponentsTestBase.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/JiraComponentsTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/JiraConnectionPropertiesTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/JiraConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/OsgiJiraComponentsTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/OsgiJiraComponentsTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/SpringJiraComponentsTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/SpringJiraComponentsTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/avro/IssueAdapterFactoryTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/avro/IssueAdapterFactoryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/avro/IssueIndexedRecordTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/avro/IssueIndexedRecordTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/datum/EntityTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/datum/EntityTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/datum/ProjectTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/datum/ProjectTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/datum/SearchTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/datum/SearchTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSinkTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceOrSinkTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceOrSinkTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceOrSinkTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraWriteOperationTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/JiraWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/reader/JiraReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraDeleteWriterTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraDeleteWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraInsertWriterTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraInsertWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraUpdateWriterTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraUpdateWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraWriterTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraWritersTestIT.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/runtime/writer/JiraWritersTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/testutils/JiraTestConstants.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/testutils/JiraTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/testutils/JiraTestsHelper.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/testutils/JiraTestsHelper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/tjirainput/TJiraInputDefinitionTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/tjirainput/TJiraInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/tjirainput/TJiraInputPropertiesTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/tjirainput/TJiraInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/tjiraoutput/TJiraOutputDefinitionTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/tjiraoutput/TJiraOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-jira/src/test/java/org/talend/components/jira/tjiraoutput/TJiraOutputPropertiesTest.java
+++ b/components/components-jira/src/test/java/org/talend/components/jira/tjiraoutput/TJiraOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaConfTableProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaConfTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaFamilyDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaIOBasedDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaIOBasedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaIOBasedProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/KafkaIOBasedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/dataset/KafkaDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/datastore/KafkaDatastoreDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/datastore/KafkaDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/datastore/KafkaDatastoreProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/datastore/KafkaDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/input/KafkaInputDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/input/KafkaInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/input/KafkaInputProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/input/KafkaInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/output/KafkaOutputDefinition.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/output/KafkaOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/output/KafkaOutputProperties.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/output/KafkaOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/runtime/IKafkaDatasetRuntime.java
+++ b/components/components-kafka/kafka-definition/src/main/java/org/talend/components/kafka/runtime/IKafkaDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/KafkaConfTablePropertiesTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/KafkaConfTablePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/dataset/KafkaDatasetDefinitionTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/dataset/KafkaDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/dataset/KafkaDatasetPropertiesTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/dataset/KafkaDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/datastore/KafkaDatastoreDefinitionTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/datastore/KafkaDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/datastore/KafkaDatastorePropertiesTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/datastore/KafkaDatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/input/KafkaInputDefinitionTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/input/KafkaInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/input/KafkaInputPropertiesTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/input/KafkaInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/output/KafkaOutputDefinitionTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/output/KafkaOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/output/KafkaOutputPropertiesTest.java
+++ b/components/components-kafka/kafka-definition/src/test/java/org/talend/components/kafka/output/KafkaOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-integration/src/test/java/org/talend/components/kafka/integration/KafkaComponentFamilyDefinitionTest.java
+++ b/components/components-kafka/kafka-integration/src/test/java/org/talend/components/kafka/integration/KafkaComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-integration/src/test/java/org/talend/components/kafka/integration/KafkaDatasetTestIT.java
+++ b/components/components-kafka/kafka-integration/src/test/java/org/talend/components/kafka/integration/KafkaDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/ExtractCsvSplit.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/ExtractCsvSplit.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaAvroRegistry.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaConnection.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaDatasetRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaDatastoreRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaInputPTransformRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaInputPTransformRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
+++ b/components/components-kafka/kafka-runtime/src/main/java/org/talend/components/kafka/runtime/KafkaOutputPTransformRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaAvroBeamRuntimeTestIT.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaAvroBeamRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaCsvBeamRuntimeTestIT.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaCsvBeamRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatasetOtherDelimTestIT.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatasetOtherDelimTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatasetTestIT.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatastoreTestIT.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaDatastoreTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaTestConstants.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/KafkaTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/Person.java
+++ b/components/components-kafka/kafka-runtime/src/test/java/org/talend/components/kafka/runtime/Person.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisComponentFamilyDefinition.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatasetDefinition.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatasetProperties.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatastoreDefinition.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatastoreProperties.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisRegion.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/KinesisRegion.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/input/KinesisInputDefinition.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/input/KinesisInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/input/KinesisInputProperties.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/input/KinesisInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/output/KinesisOutputDefinition.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/output/KinesisOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/output/KinesisOutputProperties.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/output/KinesisOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/runtime/IKinesisDatasetRuntime.java
+++ b/components/components-kinesis/kinesis-definition/src/main/java/org/talend/components/kinesis/runtime/IKinesisDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisComponentFamilyDefinitionTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisComponentTestITBase.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisComponentTestITBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatasetDefinitionTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatasetPropertiesTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatastoreDefinitionTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatastorePropertiesTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/KinesisDatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/input/KinesisInputDefinitionTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/input/KinesisInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/input/KinesisInputPropertiesTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/input/KinesisInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/output/KinesisOutputDefinitionTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/output/KinesisOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/output/KinesisOutputPropertiesTest.java
+++ b/components/components-kinesis/kinesis-definition/src/test/java/org/talend/components/kinesis/output/KinesisOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisComponentFamilyDefinitionTest.java
+++ b/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisDatasetRuntimeTestIT.java
+++ b/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisDatasetRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisDatastoreRuntimeTestIT.java
+++ b/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisDatastoreRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisInputRuntimeTestIT.java
+++ b/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisInputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisTestConstants.java
+++ b/components/components-kinesis/kinesis-integration/src/test/java/org/talend/components/kinesis/integration/KinesisTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/TalendKinesisProvider.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/TalendKinesisProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/auth/AnonymousAWSCredentialsProvider.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/auth/AnonymousAWSCredentialsProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/auth/BasicAWSCredentialsProvider.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/apache/beam/sdk/io/kinesis/auth/BasicAWSCredentialsProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisClient.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisDatasetRuntime.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisDatastoreRuntime.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisInputRuntime.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisOutputRuntime.java
+++ b/components/components-kinesis/kinesis-runtime/src/main/java/org/talend/components/kinesis/runtime/KinesisOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisDatastoreRuntimeTestIT.java
+++ b/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisDatastoreRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisInputRuntimeTestIT.java
+++ b/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisInputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisTestConstants.java
+++ b/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/KinesisTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/Person.java
+++ b/components/components-kinesis/kinesis-runtime/src/test/java/org/talend/components/kinesis/runtime/Person.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/LocalIOComponentFamilyDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/LocalIOComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/LocalIOErrorCode.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/LocalIOErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2015 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/devnull/DevNullOutputDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/devnull/DevNullOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/devnull/DevNullOutputProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/devnull/DevNullOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatasetDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatasetProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatastoreDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatastoreProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedInputDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedInputProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixed/FixedInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixedflowinput/FixedFlowInputDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixedflowinput/FixedFlowInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixedflowinput/FixedFlowInputProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/fixedflowinput/FixedFlowInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/rowgenerator/RowGeneratorDefinition.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/rowgenerator/RowGeneratorDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/rowgenerator/RowGeneratorProperties.java
+++ b/components/components-localio/localio-definition/src/main/java/org/talend/components/localio/rowgenerator/RowGeneratorProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/LocalIOComponentFamilyDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/LocalIOComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/LocalIOTestITBase.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/LocalIOTestITBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/SpringLocalIOTestIT.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/SpringLocalIOTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/devnull/DevNullOutputDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/devnull/DevNullOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/devnull/DevNullOutputPropertiesTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/devnull/DevNullOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatasetDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatasetPropertiesTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatastoreDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedInputDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedInputPropertiesTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixed/FixedInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixedflowinput/FixedFlowInputDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixedflowinput/FixedFlowInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixedflowinput/FixedFlowInputPropertiesTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/fixedflowinput/FixedFlowInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/rowgenerator/RowGeneratorDefinitionTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/rowgenerator/RowGeneratorDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/rowgenerator/RowGeneratorPropertiesTest.java
+++ b/components/components-localio/localio-definition/src/test/java/org/talend/components/localio/rowgenerator/RowGeneratorPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/LocalIOComponentFamilyDefinitionTest.java
+++ b/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/LocalIOComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedFixedFlowInputRuntimeTest.java
+++ b/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedFixedFlowInputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedFixedInputRuntimeTest.java
+++ b/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedFixedInputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedRowGeneratorRuntimeTest.java
+++ b/components/components-localio/localio-integration/src/test/java/org/talend/components/localio/integration/SandboxedRowGeneratorRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/devnull/DevNullOutputRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/devnull/DevNullOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedDatasetRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedDatastoreRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedInputRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixed/FixedInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputBoundedReader.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputBoundedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputBoundedSource.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputBoundedSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/rowgenerator/RowGeneratorRuntime.java
+++ b/components/components-localio/localio-runtime/src/main/java/org/talend/components/localio/runtime/rowgenerator/RowGeneratorRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/test/java/org/talend/components/localio/runtime/fixed/FixedInputRuntimeTest.java
+++ b/components/components-localio/localio-runtime/src/test/java/org/talend/components/localio/runtime/fixed/FixedInputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-localio/localio-runtime/src/test/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputRuntimeTest.java
+++ b/components/components-localio/localio-runtime/src/test/java/org/talend/components/localio/runtime/fixedflowinput/FixedFlowInputRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoComponentDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoComponentProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoConstants.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoFamilyDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoProvideConnectionProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoUtils.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/MarketoUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatasetDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatasetProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatastoreDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatastoreProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoInputDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoInputProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/data/MarketoInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/CompoundKeyTable.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/CompoundKeyTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/IncludeExcludeTypesTable.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/IncludeExcludeTypesTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/MarketoColumnMappingsTable.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/MarketoColumnMappingsTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/TokenTable.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/helpers/TokenTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkRuntime.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkSchemaProvider.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkSchemaProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketoinput/TMarketoInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoComponentWizardBaseProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoComponentWizardBaseProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionEditWizardDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionWizard.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionWizardDefinition.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoConnectionWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoCustomObjectsSchemasProperties.java
+++ b/components/components-marketo/components-marketo-definition/src/main/java/org/talend/components/marketo/wizard/MarketoCustomObjectsSchemasProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoComponentDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoComponentDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoComponentPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoComponentPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoConstantsTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoConstantsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoFamilyDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoTestBase.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoUtilsTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/MarketoUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatasetDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatasetPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatastoreDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoInputDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoInputPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/data/MarketoInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/helpers/MarketoColumnMappingsTableTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/helpers/MarketoColumnMappingsTableTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/helpers/TokenTableTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/helpers/TokenTableTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketobulkexec/TMarketoBulkExecPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketocampaign/TMarketoCampaignPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoconnection/TMarketoConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoinput/TMarketoInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoinput/TMarketoInputPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketoinput/TMarketoInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketolistoperation/TMarketoListOperationPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinitionTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/tmarketooutput/TMarketoOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoComponentWizardBasePropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoComponentWizardBasePropertiesTest.java
@@ -1,6 +1,6 @@
 /// ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoConnectionWizardTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoConnectionWizardTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoCustomObjectsSchemasPropertiesTest.java
+++ b/components/components-marketo/components-marketo-definition/src/test/java/org/talend/components/marketo/wizard/MarketoCustomObjectsSchemasPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/DisableIfMissingConfig.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoBaseTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoBaseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatasetRuntimeTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatasetRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatasetSourceTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatasetSourceTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatastoreRuntimeTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoDatastoreRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoInputReaderTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoInputReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoInputWriterTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoInputWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoListOperationWriterTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoListOperationWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriterTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoCampaignClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoCampaignClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientCustomObjectsTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientCustomObjectsTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoCompanyClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoCompanyClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoOpportunitiesClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoOpportunitiesClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoRESTClientBulkExecTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoRESTClientBulkExecTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoRESTClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoRESTClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoSOAPClientTestIT.java
+++ b/components/components-marketo/components-marketo-integration/src/test/java/org/talend/components/marketo/runtime/client/MarketoSOAPClientTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoBulkExecReader.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoBulkExecReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoCampaignReader.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoCampaignReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoCampaignWriter.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoCampaignWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoInputReader.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoInputWriter.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoInputWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoListOperationWriter.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoListOperationWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoOutputWriter.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoOutputWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoRuntimeException.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoRuntimeException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSink.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoWriteOperation.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoWriter.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/MarketoWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoBaseRESTClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoBaseRESTClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoBulkExecClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoBulkExecClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCampaignClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCampaignClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientService.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientServiceExtended.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientServiceExtended.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientUtils.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoClientUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCompanyClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCompanyClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCustomObjectClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoCustomObjectClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoLeadClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoLeadClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoOpportunityClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoOpportunityClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoRESTClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoRESTClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoSOAPClient.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/MarketoSOAPClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/BulkImportResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/BulkImportResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/DescribeFieldsResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/DescribeFieldsResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/PaginateResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/response/PaginateResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/BulkImport.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/BulkImport.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/FieldDescription.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/FieldDescription.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/MarketoAttributes.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/rest/type/MarketoAttributes.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/ListOperationParameters.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/ListOperationParameters.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoBaseResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoBaseResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoError.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoError.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoException.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoRecordResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoRecordResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoSyncResult.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/client/type/MarketoSyncResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatasetRuntime.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatasetSource.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatasetSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatastoreRuntime.java
+++ b/components/components-marketo/components-marketo-runtime/src/main/java/org/talend/components/marketo/runtime/data/MarketoDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoBulkExecReaderTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoBulkExecReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoCampaignReaderTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoCampaignReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoCampaignWriterTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoCampaignWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoInputReaderTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoInputReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoInputWriterTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoInputWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoListOperationWriterTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoListOperationWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriteOperationTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriterTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoOutputWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoRuntimeExceptionTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoRuntimeExceptionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoRuntimeTestBase.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoRuntimeTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSinkTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSourceTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoWriteOperationTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoWriterTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/MarketoWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoBaseRESTClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoBaseRESTClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoBulkExecClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoBulkExecClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCampaignClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCampaignClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientUtilsTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoClientUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCompanyClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCompanyClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCustomObjectClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoCustomObjectClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoLeadClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoLeadClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoOpportunityClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoOpportunityClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoSOAPClientTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/MarketoSOAPClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/ActivityTypesResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/ActivityTypesResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/BulkImportResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/BulkImportResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/DescribeFieldsResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/DescribeFieldsResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadActivitiesResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadActivitiesResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadChangesResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadChangesResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/LeadResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/PaginateResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/PaginateResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/RequestResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/RequestResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/StaticListResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/StaticListResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/SyncResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/response/SyncResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/ActivityTypeTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/ActivityTypeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/AuthenticationInfoTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/AuthenticationInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/BulkImportTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/BulkImportTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/FieldDescriptionTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/FieldDescriptionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/LeadActivityRecordTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/LeadActivityRecordTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/LeadChangeRecordTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/LeadChangeRecordTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/ListRecordTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/ListRecordTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/MarketoAttributesTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/MarketoAttributesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/SyncStatusTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/rest/type/SyncStatusTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/ListOperationParametersTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/ListOperationParametersTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoErrorTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoErrorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoExceptionTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoExceptionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoSyncResultTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/client/type/MarketoSyncResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatasetRuntimeTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatasetSourceTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatasetSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatastoreRuntimeTest.java
+++ b/components/components-marketo/components-marketo-runtime/src/test/java/org/talend/components/marketo/runtime/data/MarketoDatastoreRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/AbstractMarkLogicComponentDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/AbstractMarkLogicComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/MarkLogicFamilyDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/MarkLogicFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/MarkLogicProvideConnectionProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/MarkLogicProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/RuntimeInfoProvider.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/RuntimeInfoProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatastoreDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/data/MarkLogicDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputProperties.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicEditWizardDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicWizard.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicWizardDefinition.java
+++ b/components/components-marklogic/components-marklogic-definition/src/main/java/org/talend/components/marklogic/wizard/MarkLogicWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/DisablablePaxExam.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/MarkLogicFamilyDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/MarkLogicFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/MarkLogicInputTestBase.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/MarkLogicInputTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/OsgiMarkLogicInputTestIT.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/OsgiMarkLogicInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/SpringMarkLogicInputTestIT.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/SpringMarkLogicInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadPropertiesTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicbulkload/MarkLogicBulkLoadPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicCloseDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicClosePropertiesTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicclose/MarkLogicClosePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionPropertiesTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicconnection/MarkLogicConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputPropertiesTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicinput/MarkLogicInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputPropertiesTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/tmarklogicoutput/MarkLogicOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/wizard/MarkLogicEditWizardDefinitionTest.java
+++ b/components/components-marklogic/components-marklogic-definition/src/test/java/org/talend/components/marklogic/wizard/MarkLogicEditWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/connection/MarkLogicConnection.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/connection/MarkLogicConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetRuntime.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/data/MarkLogicDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/data/MarkLogicDatastoreRuntime.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/data/MarkLogicDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/exceptions/MarkLogicErrorCode.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/exceptions/MarkLogicErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/exceptions/MarkLogicException.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/exceptions/MarkLogicException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicSink.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicSourceOrSink.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicWriteOperation.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicWriter.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/MarkLogicWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/TMarkLogicCloseStandalone.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/TMarkLogicCloseStandalone.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/TMarkLogicConnectionStandalone.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/TMarkLogicConnectionStandalone.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/AbstractMarkLogicBulkLoadRunner.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/AbstractMarkLogicBulkLoadRunner.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicBulkLoad.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicBulkLoad.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicExternalBulkLoadRunner.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicExternalBulkLoadRunner.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicInternalBulkLoadRunner.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicInternalBulkLoadRunner.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicCriteriaReader.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicCriteriaReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicInputSink.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicInputSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicInputWriteOperation.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicInputWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicRowProcessor.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicRowProcessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicSource.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/MarkLogicSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/ResultWithLongNB.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/ResultWithLongNB.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/strategies/DocContentReader.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/runtime/input/strategies/DocContentReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/util/CommandExecutor.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/main/java/org/talend/components/marklogic/util/CommandExecutor.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDataSourceTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDataSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDatasetRuntimeTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDatastoreRuntimeTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/data/MarkLogicDatastoreRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/exceptions/MarkLogicErrorCodeTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/exceptions/MarkLogicErrorCodeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicSinkTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicSourceOrSinkTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicWriteOperationTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicWriterTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/MarkLogicWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/TMarkLogicCloseStandaloneTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/TMarkLogicCloseStandaloneTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/TMarkLogicConnectionStandaloneTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/TMarkLogicConnectionStandaloneTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicBulkLoadTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicBulkLoadTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicExternalBulkLoadRunnerTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicExternalBulkLoadRunnerTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicInternalBulkLoadRunnerTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/bulkload/MarkLogicInternalBulkLoadRunnerTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicCriteriaReaderTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicCriteriaReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicInputSinkTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicInputSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicInputWriteOperationTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicInputWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicRowProcessorTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicRowProcessorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicSourceTest.java
+++ b/components/components-marklogic/components-marklogic-runtime/src/test/java/org/talend/components/marklogic/runtime/input/MarkLogicSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteComponentDefinition.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteDatasetRuntime.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteFamilyDefinition.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteI18n.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteI18n.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteModuleProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteModuleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteProvideConnectionProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteRuntime.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteVersion.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/NetSuiteVersion.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinition.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/connection/NetSuiteConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputDefinition.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputModuleProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputModuleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/NetSuiteInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/SearchQueryProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/input/SearchQueryProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputDefinition.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputModuleProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputModuleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputProperties.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/OutputAction.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/output/OutputAction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/schema/SearchFieldInfo.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/schema/SearchFieldInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/schema/SearchInfo.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/schema/SearchInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/util/ComponentExceptions.java
+++ b/components/components-netsuite/components-netsuite-definition/src/main/java/org/talend/components/netsuite/util/ComponentExceptions.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/DisablablePaxExam.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteComponentTestBase.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteComponentTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteFamilyDefinitionTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuitePropertiesTestBase.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuitePropertiesTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteRuntimeInfoTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteRuntimeInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteVersionTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/NetSuiteVersionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/OsgiNetSuiteComponentTestIT.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/OsgiNetSuiteComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/SpringNetSuiteComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinitionTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionPropertiesTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/connection/NetSuiteConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputDefinitionTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputPropertiesTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/input/NetSuiteInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputDefinitionTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputPropertiesTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/util/ComponentExceptionsTest.java
+++ b/components/components-netsuite/components-netsuite-definition/src/test/java/org/talend/components/netsuite/util/ComponentExceptionsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/AbstractNetSuiteRuntime.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/AbstractNetSuiteRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteDatasetRuntimeImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteDatasetRuntimeImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteEndpoint.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteEndpoint.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteErrorCode.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteRuntimeI18n.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteRuntimeI18n.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSchemaConstants.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSchemaConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSink.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSourceOrSink.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NetSuiteSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NsObjectTransducer.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/NsObjectTransducer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/SchemaCustomMetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/SchemaCustomMetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/EnumToStringConverter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/EnumToStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/NullConverter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/NullConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/ObjectToJsonConverter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/ObjectToJsonConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/XMLGregorianCalendarToDateTimeConverter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/avro/converter/XMLGregorianCalendarToDateTimeConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/CustomMetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/CustomMetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/DefaultCustomMetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/DefaultCustomMetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/DefaultMetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/DefaultMetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/EmptyCustomMetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/EmptyCustomMetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/MetaDataSource.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/MetaDataSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteClientFactory.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteClientFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteClientService.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteClientService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteCredentials.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteCredentials.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteException.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NetSuiteException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsPreferences.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsPreferences.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsReadResponse.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsReadResponse.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsRef.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsRef.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsSearchPreferences.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsSearchPreferences.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsSearchResult.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsSearchResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsStatus.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsStatus.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsWriteResponse.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/NsWriteResponse.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/ResultSet.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/ResultSet.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/BasicRecordType.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/BasicRecordType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/CustomFieldDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/CustomFieldDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/CustomRecordTypeInfo.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/CustomRecordTypeInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/FieldDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/FieldDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RecordTypeDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RecordTypeDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RecordTypeInfo.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RecordTypeInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RefType.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/RefType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/SearchRecordTypeDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/SearchRecordTypeDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/SimpleFieldDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/SimpleFieldDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/TypeDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/TypeDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/TypeUtils.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/TypeUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/BeanInfo.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/BeanInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/BeanIntrospector.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/BeanIntrospector.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/Beans.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/Beans.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/EnumAccessor.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/EnumAccessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PrimitiveInfo.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PrimitiveInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyAccess.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyAccess.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyAccessor.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyAccessor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyInfo.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/beans/PropertyInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CrmCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CrmCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CustomFieldRefType.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/CustomFieldRefType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/DefaultCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/DefaultCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/EntityCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/EntityCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/ItemCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/ItemCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/ItemOptionCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/ItemOptionCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/TransactionBodyCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/TransactionBodyCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/TransactionColumnCustomFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/customfield/TransactionColumnCustomFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchBooleanFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchBooleanFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchDateFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchDateFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchDoubleFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchDoubleFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchEnumMultiSelectFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchEnumMultiSelectFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorName.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorName.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorType.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorTypeDesc.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldOperatorTypeDesc.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldType.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchFieldType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchLongFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchLongFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchMultiSelectFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchMultiSelectFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchStringFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchStringFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchTextNumberFieldAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/model/search/SearchTextNumberFieldAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchCondition.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchCondition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchQuery.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchQuery.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchResultSet.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/search/SearchResultSet.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/tools/JAXBConfigGen.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/tools/JAXBConfigGen.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/tools/MetaDataModelGen.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/client/tools/MetaDataModelGen.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/input/NetSuiteSearchInputReader.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/input/NetSuiteSearchInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/input/NsObjectInputTransducer.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/input/NsObjectInputTransducer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/json/NsTypeIdResolver.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/json/NsTypeIdResolver.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/json/NsTypeResolverBuilder.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/json/NsTypeResolverBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteAddWriter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteAddWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteDeleteWriter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteDeleteWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputWriter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteOutputWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteUpdateWriter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteUpdateWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteUpsertWriter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteUpsertWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteWriteOperation.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NetSuiteWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NsObjectOutputTransducer.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/output/NsObjectOutputTransducer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/util/Mapper.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/main/java/org/talend/components/netsuite/util/Mapper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteComponentMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteComponentMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteTestBase.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/AbstractNetSuiteTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/CustomFieldSpec.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/CustomFieldSpec.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteComponentMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteComponentMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteDatasetRuntimeTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteDatasetRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteMockTestBase.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteMockTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuitePortTypeMockAdapter.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuitePortTypeMockAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteRuntimeI18nTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteRuntimeI18nTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NetSuiteWebServiceTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NsRefTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/NsRefTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/TestNetSuiteRuntimeImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/TestNetSuiteRuntimeImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/ValueConverterTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/ValueConverterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/CustomMetaDataSourceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/CustomMetaDataSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/MetaDataSourceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/MetaDataSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/NetSuiteClientServiceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/NetSuiteClientServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/SearchQueryTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/SearchQueryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/SearchResultSetTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/SearchResultSetTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/BasicMetaDataTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/BasicMetaDataTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/RecordTypeInfoTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/RecordTypeInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TestBasicMetaDataImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TestBasicMetaDataImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TypeDescTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TypeDescTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TypeUtilsTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/TypeUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/customfield/CustomFieldAdaptersTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/customfield/CustomFieldAdaptersTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/search/SearchFieldAdaptersTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/client/model/search/SearchFieldAdaptersTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/input/NsObjectInputTransducerTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/input/NsObjectInputTransducerTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputTransducerTest.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/output/NetSuiteOutputTransducerTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/FreePortFinder.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/FreePortFinder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/MessageContextHolder.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/MessageContextHolder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/NetSuitePortTypeMockAdapterImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/NetSuitePortTypeMockAdapterImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/TestUtils.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/TestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/TestNetSuiteClientFactory.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/TestNetSuiteClientFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/TestNetSuiteClientService.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/TestNetSuiteClientService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/model/TestRecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/model/TestRecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/model/TestSearchRecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime/src/test/java/org/talend/components/netsuite/test/client/model/TestSearchRecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteRuntimeImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteRuntimeImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSourceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSourceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSourceOrSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/NetSuiteSourceOrSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientFactoryImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientFactoryImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/BasicMetaDataImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/BasicMetaDataImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/RecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/RecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/SearchRecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/model/SearchRecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/tools/MetaDataModelGenImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/main/java/org/talend/components/netsuite/v2014_2/client/tools/MetaDataModelGenImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuiteComponentMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuiteComponentMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuiteMockTestBase.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuiteMockTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuitePortTypeMockAdapterImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/NetSuitePortTypeMockAdapterImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/client/NetSuiteClientServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NetSuiteSearchInputReaderIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NetSuiteSearchInputReaderIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NetSuiteSearchInputReaderTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NetSuiteSearchInputReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NsObjectInputTransducerIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/input/NsObjectInputTransducerIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/output/NetSuiteOutputWriterTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2014_2/src/test/java/org/talend/components/netsuite/v2014_2/output/NetSuiteOutputWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteRuntimeImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteRuntimeImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSourceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSourceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSourceOrSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/NetSuiteSourceOrSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/CustomMetaDataRetrieverImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/CustomMetaDataRetrieverImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientFactoryImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientFactoryImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/BasicMetaDataImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/BasicMetaDataImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/RecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/RecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/SearchRecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/model/SearchRecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/tools/MetaDataModelGenImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/main/java/org/talend/components/netsuite/v2016_2/client/tools/MetaDataModelGenImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuiteComponentMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuiteComponentMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuiteMockTestBase.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuiteMockTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuitePortTypeMockAdapterImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/NetSuitePortTypeMockAdapterImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/client/NetSuiteClientServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NetSuiteSearchInputReaderIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NetSuiteSearchInputReaderIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NetSuiteSearchInputReaderTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NetSuiteSearchInputReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NsObjectInputTransducerIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/input/NsObjectInputTransducerIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/output/NetSuiteOutputWriterIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/output/NetSuiteOutputWriterIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/output/NetSuiteOutputWriterTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2016_2/src/test/java/org/talend/components/netsuite/v2016_2/output/NetSuiteOutputWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteRuntimeImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteRuntimeImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSourceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSourceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSourceOrSinkImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/NetSuiteSourceOrSinkImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/CustomMetaDataRetrieverImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/CustomMetaDataRetrieverImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientFactoryImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientFactoryImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/BasicMetaDataImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/BasicMetaDataImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/RecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/RecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/SearchRecordTypeEnum.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/main/java/org/talend/components/netsuite/v2018_2/client/model/SearchRecordTypeEnum.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuiteComponentMockTestFixture.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuiteComponentMockTestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuiteMockTestBase.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuiteMockTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuitePortTypeMockAdapterImpl.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/NetSuitePortTypeMockAdapterImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/client/NetSuiteClientServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NetSuiteSearchInputReaderIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NetSuiteSearchInputReaderIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NetSuiteSearchInputReaderTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NetSuiteSearchInputReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NsObjectInputTransducerIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/input/NsObjectInputTransducerIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/output/NetSuiteOutputWriterIT.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/output/NetSuiteOutputWriterIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/output/NetSuiteOutputWriterTest.java
+++ b/components/components-netsuite/components-netsuite-runtime_2018_2/src/test/java/org/talend/components/netsuite/v2018_2/output/NetSuiteOutputWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/ProcessingErrorCode.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/ProcessingErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2015 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/ProcessingFamilyDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/ProcessingFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/FieldSelectorDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/FieldSelectorDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/FieldSelectorProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/FieldSelectorProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/SelectorProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/fieldselector/SelectorProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/ConditionsRowConstant.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/ConditionsRowConstant.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/FilterRowDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/FilterRowDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/FilterRowProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/FilterRowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/LogicalOpType.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/filterrow/LogicalOpType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/limit/LimitDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/limit/LimitDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/limit/LimitProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/limit/LimitProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeConstant.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeConstant.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeDelimiter.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeDelimiter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/normalize/NormalizeProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/MapType.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/MapType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/PythonRowDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/PythonRowDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/PythonRowProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/pythonrow/PythonRowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/replicate/ReplicateDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/replicate/ReplicateDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/replicate/ReplicateProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/replicate/ReplicateProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/typeconverter/TypeConverterDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/typeconverter/TypeConverterDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/typeconverter/TypeConverterProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/typeconverter/TypeConverterProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/window/WindowDefinition.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/window/WindowDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/window/WindowProperties.java
+++ b/components/components-processing/processing-definition/src/main/java/org/talend/components/processing/definition/window/WindowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/fieldselector/FieldSelectorDefinitionTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/fieldselector/FieldSelectorDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/fieldselector/FieldSelectorPropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/fieldselector/FieldSelectorPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowCriteriaPropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowCriteriaPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowDefinitionTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowPropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowTestBase.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/filterrow/FilterRowTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/normalize/NormalizeDefinitionTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/normalize/NormalizeDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/normalize/NormalizePropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/normalize/NormalizePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowDefinitionTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowPropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowTestBase.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/pythonrow/PythonRowTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/replicate/ReplicateDefinitionTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/replicate/ReplicateDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/replicate/ReplicatePropertiesTest.java
+++ b/components/components-processing/processing-definition/src/test/java/org/talend/components/processing/definition/replicate/ReplicatePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFn.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorRuntime.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtil.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtil.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFn.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowPredicate.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowPredicate.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowRuntime.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowUtils.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/FilterRowUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/TypeConverterUtils.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/filterrow/TypeConverterUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/limit/LimitDoFn.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/limit/LimitDoFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/limit/LimitRuntime.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/limit/LimitRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeDoFn.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeDoFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeRuntime.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeUtils.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/normalize/NormalizeUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/pythonrow/PythonRowDoFn.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/pythonrow/PythonRowDoFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/window/WindowRuntime.java
+++ b/components/components-processing/processing-runtime/src/main/java/org/talend/components/processing/runtime/window/WindowRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFnTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorDoFnTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtilTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/fieldselector/FieldSelectorUtilTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFnAvpathTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFnAvpathTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFnTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/FilterRowDoFnTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/TypeConverterUtilsTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/filterrow/TypeConverterUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/limit/LimitRuntimeTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/limit/LimitRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/normalize/NormalizeDoFnTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/normalize/NormalizeDoFnTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/normalize/NormalizeUtilsTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/normalize/NormalizeUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/pythonrow/PythonRowDoFnTest.java
+++ b/components/components-processing/processing-runtime/src/test/java/org/talend/components/processing/runtime/pythonrow/PythonRowDoFnTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubComponentFamilyDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatastoreDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatastoreProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/PubSubDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/input/PubSubInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputDefinition.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputProperties.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/output/PubSubOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/runtime/IPubSubDatasetRuntime.java
+++ b/components/components-pubsub/pubsub-definition/src/main/java/org/talend/components/pubsub/runtime/IPubSubDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubComponentFamilyDefinitionTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatasetDefinitionTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatasetPropertiesTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatastoreDefinitionTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatastorePropertiesTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/PubSubDatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/input/PubSubInputDefinitionTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/input/PubSubInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/input/PubSubInputPropertiesTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/input/PubSubInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/output/PubSubOutputDefinitionTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/output/PubSubOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/output/PubSubOutputPropertiesTest.java
+++ b/components/components-pubsub/pubsub-definition/src/test/java/org/talend/components/pubsub/output/PubSubOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-integration/src/test/java/org/talend/components/pubsub/integration/PubSubComponentFamilyDefinitionTest.java
+++ b/components/components-pubsub/pubsub-integration/src/test/java/org/talend/components/pubsub/integration/PubSubComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-integration/src/test/java/org/talend/components/pubsub/integration/PubSubDatasetTestIT.java
+++ b/components/components-pubsub/pubsub-integration/src/test/java/org/talend/components/pubsub/integration/PubSubDatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/ExtractCsvSplit.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/ExtractCsvSplit.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubAvroRegistry.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubClient.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubConnection.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubDatasetRuntime.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubDatastoreRuntime.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubInputRuntime.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubInputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubOutputRuntime.java
+++ b/components/components-pubsub/pubsub-runtime/src/main/java/org/talend/components/pubsub/runtime/PubSubOutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/DisableIfMissingConfig.java
+++ b/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/Person.java
+++ b/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/Person.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/PubSubTestConstants.java
+++ b/components/components-pubsub/pubsub-runtime/src/test/java/org/talend/components/pubsub/runtime/PubSubTestConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceBulkProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceBulkProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionEditWizardDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionModuleProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionModuleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionWizard.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionWizardDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceConnectionWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceFamilyDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceGetDeletedUpdatedProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceGetDeletedUpdatedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleListProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleWizard.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleWizardDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceModuleWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceOutputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceProvideConnectionProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceUserPasswordProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/SalesforceUserPasswordProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/UpsertRelationTable.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/UpsertRelationTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/common/SalesforceErrorCodes.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/common/SalesforceErrorCodes.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/common/SalesforceRuntimeSourceOrSink.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/common/SalesforceRuntimeSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataprep/SalesforceInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/dataset/SalesforceDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/datastore/SalesforceDatastoreDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/datastore/SalesforceDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/datastore/SalesforceDatastoreProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/datastore/SalesforceDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceconnection/TSalesforceConnectionDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceconnection/TSalesforceConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecDefinition.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecProperties.java
+++ b/components/components-salesforce/components-salesforce-definition/src/main/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceConnectionWizardDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceConnectionWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceFamilyDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceGetDeletedUpdatedPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceGetDeletedUpdatedPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceModuleListPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceModuleListPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceModuleWizardDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceModuleWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceTestBase.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/SalesforceTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/TestUtils.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/TestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/common/ExceptionUtilTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/common/ExceptionUtilTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/common/SalesforceErrorCodesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/common/SalesforceErrorCodesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataprep/SalesforceInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataprep/SalesforceInputPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataprep/SalesforceInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataset/SalesforceDatasetDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataset/SalesforceDatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataset/SalesforceDatasetPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/dataset/SalesforceDatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/datastore/SalesforceDatastoreDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/datastore/SalesforceDatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/test/SalesforceConnectionPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/test/SalesforceConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/test/SalesforceTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/test/SalesforceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcebulkexec/TSalesforceBulkExecPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceconnection/TSalesforceConnectionDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceconnection/TSalesforceConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetdeleted/TSalesforceGetDeletedDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetservertimestamp/TSalesforceGetServerTimestampPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforcegetupdated/TSalesforceGetUpdatedDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutput/TSalesforceOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulk/TSalesforceOutputBulkPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecDefinitionTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecPropertiesTest.java
+++ b/components/components-salesforce/components-salesforce-definition/src/test/java/org/talend/components/salesforce/tsalesforceoutputbulkexec/TSalesforceOutputBulkExecPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/DisableIfMissingConfig.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OAthDepsTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OAthDepsTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OsgiSalesforceComponentTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OsgiSalesforceComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OsgiSalesforceEsbTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/OsgiSalesforceEsbTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SalesforceComponentTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SalesforceComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SalesforceTestBase.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SalesforceTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SpringSalesforceComponentTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/integration/SpringSalesforceComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceAnyTypeFieldTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceAnyTypeFieldTestIT.java
@@ -1,6 +1,6 @@
 //  ============================================================================
 //
-//  Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//  Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 //  This source code is available under agreement available at
 //  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedUpdatedReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedUpdatedReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceInputReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceInputReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceRuntimeTestUtil.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceRuntimeTestUtil.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceServerTimeStampReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceServerTimeStampReaderTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSinkTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSinkTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceWriterTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputPropertiesIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/tsalesforceinput/TSalesforceInputPropertiesIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceImplicitConnection.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceImplicitConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceJwtConnection.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceJwtConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceOAuthAccessTokenResponse.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceOAuthAccessTokenResponse.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceOAuthConnection.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/connection/oauth/SalesforceOAuthConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/BulkResultAdapterFactory.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/BulkResultAdapterFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SObjectAdapterFactory.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SObjectAdapterFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistry.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkExecRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkExecRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileSink.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriteOperation.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriter.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkQueryInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkV2ExecReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkV2ExecReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedUpdatedReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetDeletedUpdatedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetUpdatedReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceGetUpdatedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceInputReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceInputReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSchemaConstants.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSchemaConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceServerTimeStampReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceServerTimeStampReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSink.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSource.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriteOperation.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriter.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/BulkV2Connection.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/BulkV2Connection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/JobInfoV2.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/JobInfoV2.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/SalesforceBulkV2Runtime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/SalesforceBulkV2Runtime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/error/BulkV2ClientException.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/error/BulkV2ClientException.java
@@ -1,7 +1,7 @@
 
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/request/CreateJobRequest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/request/CreateJobRequest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/request/UpdateJobRequest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/request/UpdateJobRequest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/type/HttpMethod.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/bulk/v2/type/HttpMethod.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/BulkResultIndexedRecordConverter.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/BulkResultIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryString.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceAvroRegistryString.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceBulkQueryReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDataprepSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatasetRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatastoreRuntime.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/dataprep/SalesforceDatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/SoqlQuery.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/SoqlQuery.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/SoqlQueryBuilder.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/SoqlQueryBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/parser/SoqlErrorListener.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/soql/parser/SoqlErrorListener.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultAdapterFactoryTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultAdapterFactoryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultSetTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultSetTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/BulkResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SObjectAdapterFactoryTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SObjectAdapterFactoryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceBulkFileWriteOperationTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceBulkFileWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceBulkRuntimeTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceBulkRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceRuntimeTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceRuntimeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceWriteOperationTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/SalesforceWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/DisableIfMissingConfig.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistryTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceAvroRegistryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriterTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriterTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkFileWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkLoadTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkLoadTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceProxyTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceProxyTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSchemaTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSchemaTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSessionReuseTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSessionReuseTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/SalesforceSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/common/SalesforceRuntimeCommonTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/common/SalesforceRuntimeCommonTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/BulkResultIndexedRecordConverterTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/BulkResultIndexedRecordConverterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceInputTestIT.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceInputTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceSchemaUtilsTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/runtime/dataprep/SalesforceSchemaUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/soql/SoqlQueryBuilderTest.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/soql/SoqlQueryBuilderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/test/SalesforceRuntimeTestUtil.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/test/SalesforceRuntimeTestUtil.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/test/SalesforceTestBase.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/test/java/org/talend/components/salesforce/test/SalesforceTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionEditWizardDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionEditWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionTableProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionWizard.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionWizardDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeConnectionWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDbTypeProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDbTypeProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeFamilyDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeGuessSchemaProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeGuessSchemaProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakePreparedStatementTableProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakePreparedStatementTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeProvideConnectionProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeProvideConnectionProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeRollbackAndCommitProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeRollbackAndCommitProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeRuntimeSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeRuntimeSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableListProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableListProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableWizard.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableWizardDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTableWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTypes.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeTypes.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/objects/DatabaseObject.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/objects/DatabaseObject.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/objects/TableObject.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/objects/TableObject.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakecommit/TSnowflakeCommitDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakecommit/TSnowflakeCommitDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeconnection/TSnowflakeConnectionDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeconnection/TSnowflakeConnectionDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerollback/TSnowflakeRollbackDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerollback/TSnowflakeRollbackDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowDefinition.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeConnectionPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeConnectionPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeConnectionWizardDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeConnectionWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeFamilyDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakePreparedStatementTablePropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakePreparedStatementTablePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeRollbackAndCommitPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeRollbackAndCommitPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTableListPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTableListPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTablePropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTablePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTableWizardDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTableWizardDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTestBase.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/SnowflakeTestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/TestUtils.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/TestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/migration/TSnowflakeOutputMigrationTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/migration/TSnowflakeOutputMigrationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/objects/TableObjectTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/objects/TableObjectTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeCloseDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeClosePropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeclose/TSnowflakeClosePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakecommit/TSnowflakeCommitDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakecommit/TSnowflakeCommitDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeconnection/TSnowflakeConnectionDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeconnection/TSnowflakeConnectionDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeinput/TSnowflakeInputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerollback/TSnowflakeRollbackDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerollback/TSnowflakeRollbackDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowDefinitionTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakerow/TSnowflakeRowPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/DisableIfMissingConfig.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/DisableIfMissingConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/LoaderIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/LoaderIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/OsgiSnowflakeTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/OsgiSnowflakeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeCommitAndRollbackTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeCommitAndRollbackTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeDateTypeTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeDateTypeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeReadersTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeReadersTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRowTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRuntimeIOTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRuntimeIOTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRuntimeIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeRuntimeIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeWritersTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SnowflakeWritersTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SpringSnowflakeTestIT.java
+++ b/components/components-snowflake/components-snowflake-integration/src/test/java/org/talend/components/snowflake/test/SpringSnowflakeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/Formatter.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/Formatter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistry.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeCloseSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeCloseSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeCommitSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeCommitSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeConstants.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeReader.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeResultListener.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeResultListener.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeResultSetIndexedRecordConverter.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeResultSetIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRollbackSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRollbackSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowReader.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSource.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowStandalone.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowStandalone.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowWriteOperation.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowWriter.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRowWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRuntime.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSource.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSink.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeStandaloneOperation.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeStandaloneOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriteOperation.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriter.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/SnowflakeWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/tableaction/SnowflakeTableActionConfig.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/tableaction/SnowflakeTableActionConfig.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/DriverManagerUtils.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/DriverManagerUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/SchemaResolver.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/SchemaResolver.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/SnowflakePreparedStatementUtils.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/main/java/org/talend/components/snowflake/runtime/utils/SnowflakePreparedStatementUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/FormatterTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/FormatterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistryTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeAvroRegistryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeCloseSourceOrSinkTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeCloseSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeConstantsTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeConstantsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeReaderTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeResultListenerTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeResultListenerTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowReaderTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowSinkTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowSourceTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowStandaloneTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowStandaloneTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowWriteOperationTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowWriterTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeRowWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSinkTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSinkTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSourceOrSinkTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSourceTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeSourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeWriteOperationTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeWriteOperationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeWriterTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/SnowflakeWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/tableaction/DefaultSQLCreateTableActionTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/tableaction/DefaultSQLCreateTableActionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/utils/SnowflakePreparedStatementUtilsTest.java
+++ b/components/components-snowflake/components-snowflake-runtime/src/test/java/org/talend/components/snowflake/runtime/utils/SnowflakePreparedStatementUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/src/main/java/org/talend/components/snowflake/SnowflakeGuessSchemaProperties.java
+++ b/components/components-snowflake/src/main/java/org/talend/components/snowflake/SnowflakeGuessSchemaProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/src/main/java/org/talend/components/snowflake/runtime/utils/SchemaResolver.java
+++ b/components/components-snowflake/src/main/java/org/talend/components/snowflake/runtime/utils/SchemaResolver.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-snowflake/src/test/java/org/talend/components/snowflake/test/SnowflakeRowTestIT.java
+++ b/components/components-snowflake/src/test/java/org/talend/components/snowflake/test/SnowflakeRowTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/SplunkFamilyDefinition.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/SplunkFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/TSplunkEventCollectorDefinition.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/TSplunkEventCollectorDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/TSplunkEventCollectorProperties.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/TSplunkEventCollectorProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/connection/TSplunkEventCollectorConnection.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/connection/TSplunkEventCollectorConnection.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEvent.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEvent.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEventBuilder.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEventBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEventField.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/objects/SplunkJSONEventField.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/SplunkWriterResult.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/SplunkWriterResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorSink.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriteOperation.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriter.java
+++ b/components/components-splunk/src/main/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/test/java/org/talend/components/splunk/TSplunkEventCollectorTestIT.java
+++ b/components/components-splunk/src/test/java/org/talend/components/splunk/TSplunkEventCollectorTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/test/java/org/talend/components/splunk/objects/SplunkJSONEventTest.java
+++ b/components/components-splunk/src/test/java/org/talend/components/splunk/objects/SplunkJSONEventTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/components/components-splunk/src/test/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriterTestIT.java
+++ b/components/components-splunk/src/test/java/org/talend/components/splunk/runtime/TSplunkEventCollectorWriterTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamAdapterErrorCode.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamAdapterErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2015 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobBuilder.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobBuilder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobContext.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobContext.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobRuntimeContainer.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamJobRuntimeContainer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamLocalRunnerOption.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/BeamLocalRunnerOption.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompBoundedSourceAdapter.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompBoundedSourceAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompSinkAdapter.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/TCompSinkAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/AvroSchemaHolder.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/AvroSchemaHolder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoder.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoderProviderRegistrar.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/coders/LazyAvroCoderProviderRegistrar.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/GcpServiceAccountOptions.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/GcpServiceAccountOptions.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/ServiceAccountCredentialFactory.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/gcp/ServiceAccountCredentialFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunction.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunctions.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunctions.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIO.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIO.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/ExtractKVFn.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/ExtractKVFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/KeyValueUtils.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/KeyValueUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/MergeKVFn.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/MergeKVFn.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/SchemaGeneratorUtils.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/kv/SchemaGeneratorUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecord.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecord.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/DirectCollector.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/DirectCollector.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/DirectConsumerCollector.java
+++ b/core/components-adapter-beam/src/main/java/org/talend/components/adapter/beam/transform/DirectConsumerCollector.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunctionsTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/io/rowgenerator/GeneratorFunctionsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIOTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/io/rowgenerator/RowGeneratorIOTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/kv/KeyValueUtilsTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/kv/KeyValueUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/kv/SchemaGeneratorUtilsTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/kv/SchemaGeneratorUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecordTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/ConvertToIndexedRecordTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/DirectCollectorTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/DirectCollectorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/DirectConsumerCollectorTest.java
+++ b/core/components-adapter-beam/src/test/java/org/talend/components/adapter/beam/transform/DirectConsumerCollectorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultProperties.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultResult.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultSink.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultSourceOrSink.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultWriteOperation.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultWriter.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/AssertResultWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowProperties.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowReader.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowSource.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowSourceOrSink.java
+++ b/core/components-adapter-beam/test/main/java/org/talend/components/adapter/beam/example/FixedFlowSourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/AbstractComponentFamilyDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/AbstractComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/AbstractTopLevelDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/AbstractTopLevelDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/ComponentFamilyDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/ComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/ComponentInstaller.java
+++ b/core/components-api/src/main/java/org/talend/components/api/ComponentInstaller.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/Constants.java
+++ b/core/components-api/src/main/java/org/talend/components/api/Constants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/AbstractComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/ComponentDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/ComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/ComponentImageType.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/ComponentImageType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/Connector.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/Connector.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/ConnectorTopology.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/ConnectorTopology.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/ISchemaListener.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/ISchemaListener.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/PropertyPathConnector.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/PropertyPathConnector.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/VirtualComponentDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/VirtualComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/AbstractBoundedReader.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/AbstractBoundedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/BoundedReader.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/BoundedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/BoundedSource.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/BoundedSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/ComponentDriverInitialization.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/ComponentDriverInitialization.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/DependenciesReader.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/DependenciesReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/ExecutionEngine.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/ExecutionEngine.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/JarRuntimeInfo.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/JarRuntimeInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/Reader.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/Reader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/ReaderDataProvider.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/ReaderDataProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/Result.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/Result.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/RuntimableRuntime.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/RuntimableRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/SimpleRuntimeInfo.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/SimpleRuntimeInfo.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/Sink.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/Sink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/Source.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/Source.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/SourceOrSink.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/SourceOrSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/UnboundedReader.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/UnboundedReader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/UnboundedSource.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/UnboundedSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriteOperation.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/Writer.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/Writer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriterDataSupplier.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriterDataSupplier.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriterWithFeedback.java
+++ b/core/components-api/src/main/java/org/talend/components/api/component/runtime/WriterWithFeedback.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/container/DefaultComponentRuntimeContainerImpl.java
+++ b/core/components-api/src/main/java/org/talend/components/api/container/DefaultComponentRuntimeContainerImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/container/RuntimeContainer.java
+++ b/core/components-api/src/main/java/org/talend/components/api/container/RuntimeContainer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/exception/ComponentException.java
+++ b/core/components-api/src/main/java/org/talend/components/api/exception/ComponentException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/exception/DataRejectException.java
+++ b/core/components-api/src/main/java/org/talend/components/api/exception/DataRejectException.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/exception/error/ComponentsApiErrorCode.java
+++ b/core/components-api/src/main/java/org/talend/components/api/exception/error/ComponentsApiErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/exception/error/ComponentsErrorCode.java
+++ b/core/components-api/src/main/java/org/talend/components/api/exception/error/ComponentsErrorCode.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentBasePropertiesImpl.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentBasePropertiesImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentEncryption.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentEncryption.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentKeySource.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentKeySource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentProperties.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentPropertiesImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/ComponentReferenceProperties.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/ComponentReferenceProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/properties/VirtualComponentProperties.java
+++ b/core/components-api/src/main/java/org/talend/components/api/properties/VirtualComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/service/ComponentService.java
+++ b/core/components-api/src/main/java/org/talend/components/api/service/ComponentService.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/wizard/AbstractComponentWizardDefintion.java
+++ b/core/components-api/src/main/java/org/talend/components/api/wizard/AbstractComponentWizardDefintion.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/wizard/ComponentWizard.java
+++ b/core/components-api/src/main/java/org/talend/components/api/wizard/ComponentWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/wizard/ComponentWizardDefinition.java
+++ b/core/components-api/src/main/java/org/talend/components/api/wizard/ComponentWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/main/java/org/talend/components/api/wizard/WizardImageType.java
+++ b/core/components-api/src/main/java/org/talend/components/api/wizard/WizardImageType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/AbstractTopLevelDefinitionTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/AbstractTopLevelDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/ToStringIndentUtilTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/ToStringIndentUtilTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/ComponentDefinitionTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/ComponentDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/ComponentImageTypeTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/ComponentImageTypeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/PropertyPathConnectorTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/PropertyPathConnectorTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/runtime/DependenciesReaderTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/runtime/DependenciesReaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/runtime/JarRuntimeInfoTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/runtime/JarRuntimeInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/runtime/ReaderDataProviderTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/runtime/ReaderDataProviderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/runtime/ResultTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/runtime/ResultTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/component/runtime/SimpleRuntimeInfoTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/component/runtime/SimpleRuntimeInfoTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/exception/ComponentExceptionTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/exception/ComponentExceptionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/exception/error/ComponentsErrorCodeTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/exception/error/ComponentsErrorCodeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/properties/ComponentEncryptionTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/properties/ComponentEncryptionTest.java
@@ -2,7 +2,7 @@ package org.talend.components.api.properties;
 
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/properties/ComponentKeySourceTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/properties/ComponentKeySourceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/properties/ComponentPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/properties/ComponentReferencePropertiesTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/properties/ComponentReferencePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/AbstractComponentTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/AbstractComponentTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/AbstractComponentTest2.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/AbstractComponentTest2.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/ComponentTestUtils.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/ComponentTestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/SimpleComponentDefinition.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/SimpleComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/ContiPerfRuleAdaptor.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/ContiPerfRuleAdaptor.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/ReflectionUtils.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/ReflectionUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/RunAftersContiPerfAdapter.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/RunAftersContiPerfAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/RunBeforesContiPerfAdapter.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/RunBeforesContiPerfAdapter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/example/ComponentPropertiesInitializationTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/example/ComponentPropertiesInitializationTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/report/PerformanceTestsRegistry.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/report/PerformanceTestsRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/report/PerformanceTestsResultHolder.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/report/PerformanceTestsResultHolder.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/report/TestMethodCompletionResult.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/report/TestMethodCompletionResult.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/report/TestMethodReportDefinition.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/report/TestMethodReportDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/test/performance/report/XmlJUnitReportModule.java
+++ b/core/components-api/src/test/java/org/talend/components/api/test/performance/report/XmlJUnitReportModule.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/testcomponent/ComponentPropertiesWithDefinedI18N.java
+++ b/core/components-api/src/test/java/org/talend/components/api/testcomponent/ComponentPropertiesWithDefinedI18N.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/testcomponent/TestComponentDefinition.java
+++ b/core/components-api/src/test/java/org/talend/components/api/testcomponent/TestComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/testcomponent/TestComponentProperties.java
+++ b/core/components-api/src/test/java/org/talend/components/api/testcomponent/TestComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/testcomponent/nestedprop/NestedComponentProperties.java
+++ b/core/components-api/src/test/java/org/talend/components/api/testcomponent/nestedprop/NestedComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/testcomponent/nestedprop/inherited/InheritedComponentProperties.java
+++ b/core/components-api/src/test/java/org/talend/components/api/testcomponent/nestedprop/inherited/InheritedComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/wizard/TestComponentWizard.java
+++ b/core/components-api/src/test/java/org/talend/components/api/wizard/TestComponentWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/wizard/TestComponentWizardDefinition.java
+++ b/core/components-api/src/test/java/org/talend/components/api/wizard/TestComponentWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/wizard/WizardNameComparator.java
+++ b/core/components-api/src/test/java/org/talend/components/api/wizard/WizardNameComparator.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-api/src/test/java/org/talend/components/api/wizard/WizardTest.java
+++ b/core/components-api/src/test/java/org/talend/components/api/wizard/WizardTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Jwt.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Jwt.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/OAuth2FlowType.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/OAuth2FlowType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Oauth2ImplicitClient.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Oauth2ImplicitClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Oauth2JwtClient.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/Oauth2JwtClient.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/X509Key.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/X509Key.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/properties/Oauth2ImplicitFlowProperties.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/properties/Oauth2ImplicitFlowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/properties/Oauth2JwtFlowProperties.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/properties/Oauth2JwtFlowProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/server/OAuth2ImplicitGrantServer.java
+++ b/core/components-common-oauth/src/main/java/org/talend/components/common/oauth/server/OAuth2ImplicitGrantServer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/AzureOauth2JwtExample.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/AzureOauth2JwtExample.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/JwtTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/JwtTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/Oauth2JwtClientTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/Oauth2JwtClientTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/X509KeyTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/X509KeyTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/properties/Oauth2ImplicitFlowPropertiesTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/properties/Oauth2ImplicitFlowPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/properties/Oauth2JwtFlowPropertiesTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/properties/Oauth2JwtFlowPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/server/Auth2ImplicitGrantServerTest.java
+++ b/core/components-common-oauth/src/test/java/org/talend/components/common/oauth/server/Auth2ImplicitGrantServerTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/BasedOnSchemaTable.java
+++ b/core/components-common/src/main/java/org/talend/components/common/BasedOnSchemaTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/BulkFileProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/BulkFileProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/CommonTags.java
+++ b/core/components-common/src/main/java/org/talend/components/common/CommonTags.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/ComponentConstants.java
+++ b/core/components-common/src/main/java/org/talend/components/common/ComponentConstants.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/EncodingTypeProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/EncodingTypeProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/FixedConnectorsComponentProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/FixedConnectorsComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/ProxyProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/ProxyProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/SchemaProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/SchemaProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/SslProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/SslProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/TrimFieldsTable.java
+++ b/core/components-common/src/main/java/org/talend/components/common/TrimFieldsTable.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/UserPasswordProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/UserPasswordProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/ValuesTrimProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/ValuesTrimProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistry.java
+++ b/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistryInfluencer.java
+++ b/core/components-common/src/main/java/org/talend/components/common/avro/JDBCAvroRegistryInfluencer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/avro/JDBCResultSetIndexedRecordConverter.java
+++ b/core/components-common/src/main/java/org/talend/components/common/avro/JDBCResultSetIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/avro/RootSchemaUtils.java
+++ b/core/components-common/src/main/java/org/talend/components/common/avro/RootSchemaUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/component/runtime/RootRecordUtils.java
+++ b/core/components-common/src/main/java/org/talend/components/common/component/runtime/RootRecordUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/AvroTypeConverter.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/AvroTypeConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/Dbms.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/Dbms.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/DbmsType.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/DbmsType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/MappingFileLoader.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/MappingFileLoader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/MappingType.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/MappingType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/config/jdbc/TalendType.java
+++ b/core/components-common/src/main/java/org/talend/components/common/config/jdbc/TalendType.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/dataset/DatasetDefinition.java
+++ b/core/components-common/src/main/java/org/talend/components/common/dataset/DatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/dataset/DatasetProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/dataset/DatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/dataset/runtime/DatasetRuntime.java
+++ b/core/components-common/src/main/java/org/talend/components/common/dataset/runtime/DatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/datastore/DatastoreDefinition.java
+++ b/core/components-common/src/main/java/org/talend/components/common/datastore/DatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/datastore/DatastoreProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/datastore/DatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/datastore/runtime/DatastoreRuntime.java
+++ b/core/components-common/src/main/java/org/talend/components/common/datastore/runtime/DatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/file/fileformat/FileFormatDefinition.java
+++ b/core/components-common/src/main/java/org/talend/components/common/file/fileformat/FileFormatDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/file/fileformat/FileFormatProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/file/fileformat/FileFormatProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/file/filesystem/FileSystemDefinition.java
+++ b/core/components-common/src/main/java/org/talend/components/common/file/filesystem/FileSystemDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/file/filesystem/FileSystemProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/file/filesystem/FileSystemProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/format/FormatPropertiesProvider.java
+++ b/core/components-common/src/main/java/org/talend/components/common/format/FormatPropertiesProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/io/IOProperties.java
+++ b/core/components-common/src/main/java/org/talend/components/common/io/IOProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileSink.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileSink.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileWriteOperation.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileWriteOperation.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileWriter.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/BulkFileWriter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/DynamicSchemaUtils.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/DynamicSchemaUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/FastDateParser.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/FastDateParser.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/FileRuntimeHelper.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/FileRuntimeHelper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/FormatterUtils.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/FormatterUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/GenericAvroRegistry.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/GenericAvroRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/GenericIndexedRecordConverter.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/GenericIndexedRecordConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/ParserUtils.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/ParserUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/ProxyPropertiesRuntimeHelper.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/ProxyPropertiesRuntimeHelper.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/runtime/SharedConnectionsPool.java
+++ b/core/components-common/src/main/java/org/talend/components/common/runtime/SharedConnectionsPool.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/ConvertAvroTypeToSQL.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/ConvertAvroTypeToSQL.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLClearTableAction.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLClearTableAction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLCreateTableAction.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLCreateTableAction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLTruncateTableAction.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLTruncateTableAction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/NoAction.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/NoAction.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/TableActionConfig.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/TableActionConfig.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/TableActionManager.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/TableActionManager.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/AllPropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/AllPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/CommonTestUtils.java
+++ b/core/components-common/src/test/java/org/talend/components/common/CommonTestUtils.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/EncodingTypePropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/EncodingTypePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/ProxyPropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/ProxyPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/SchemaPropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/SchemaPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/SslPropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/SslPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/TestFixedConnectorComponentProperties.java
+++ b/core/components-common/src/test/java/org/talend/components/common/TestFixedConnectorComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/ValuesTrimPropertiesTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/ValuesTrimPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/avro/RootSchemaUtilsTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/avro/RootSchemaUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/component/runtime/RootRecordUtilsTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/component/runtime/RootRecordUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/AvroTypeConverterTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/AvroTypeConverterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/DbmsTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/DbmsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/DbmsTypeTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/DbmsTypeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/MappingFileLoaderTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/MappingFileLoaderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/MappingTypeTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/MappingTypeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/config/jdbc/TalendTypeTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/config/jdbc/TalendTypeTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/FormatPropertiesProviderTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/FormatPropertiesProviderTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/AbstractTestFormatDefinition.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/AbstractTestFormatDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/AbstractTestFormatProperties.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/AbstractTestFormatProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatDefinition1Impl.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatDefinition1Impl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatDefinition2Impl.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatDefinition2Impl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatProperties1Impl.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatProperties1Impl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatProperties2Impl.java
+++ b/core/components-common/src/test/java/org/talend/components/common/format/instances/TestFormatProperties2Impl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/runtime/BulkFileWriterTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/runtime/BulkFileWriterTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/runtime/DynamicSchemaUtilsTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/runtime/DynamicSchemaUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/runtime/FileRuntimeHelperTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/runtime/FileRuntimeHelperTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/runtime/ParserUtilsTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/runtime/ParserUtilsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/runtime/ProxyPropertiesRuntimeHelperTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/runtime/ProxyPropertiesRuntimeHelperTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/test/ComponentCommonTestIT.java
+++ b/core/components-common/src/test/java/org/talend/components/common/test/ComponentCommonTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-common/src/test/java/org/talend/components/common/test/DisablablePaxExam.java
+++ b/core/components-common/src/test/java/org/talend/components/common/test/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/components-common/src/test/java/org/talend/components/common/test/TestFixture.java
+++ b/core/components-common/src/test/java/org/talend/components/common/test/TestFixture.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-osgi-test/components-osgitest/src/main/java/org/talend/components/api/ComponentsPaxExamOptions.java
+++ b/core/components-osgi-test/components-osgitest/src/main/java/org/talend/components/api/ComponentsPaxExamOptions.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/ComponentsPaxExamOptionsTest.java
+++ b/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/ComponentsPaxExamOptionsTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/DisablablePaxExam.java
+++ b/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/OsgiComponentServiceTest.java
+++ b/core/components-osgi-test/components-osgitest/src/test/java/org/talend/components/api/OsgiComponentServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-osgi-test/osgi-test-component/src/main/java/org/talend/components/testcomponent/TestComponentFamilyDefinition.java
+++ b/core/components-osgi-test/osgi-test-component/src/main/java/org/talend/components/testcomponent/TestComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/core/components-osgi-test/osgi-test-component/src/main/java/org/talend/components/testcomponent/testcomp/TestComponentDefinition.java
+++ b/core/components-osgi-test/osgi-test-component/src/main/java/org/talend/components/testcomponent/testcomp/TestComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__ComponentFamilyDefinition.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__ComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatasetDefinition.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatasetProperties.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatastoreDefinition.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatastoreProperties.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/__componentNameClass__DatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/input/__componentNameClass__InputDefinition.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/input/__componentNameClass__InputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/input/__componentNameClass__InputProperties.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/input/__componentNameClass__InputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/output/__componentNameClass__OutputDefinition.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/output/__componentNameClass__OutputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/output/__componentNameClass__OutputProperties.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/main/java/definition/output/__componentNameClass__OutputProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__ComponentFamilyDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__ComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatasetDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatasetDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatasetPropertiesTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatasetPropertiesTest.java
@@ -1,6 +1,6 @@
 // ===========================================================================definition.=
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatastoreDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatastoreDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatastorePropertiesTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/__componentNameClass__DatastorePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/input/__componentNameClass__InputDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/input/__componentNameClass__InputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/input/__componentNameClass__InputPropertiesTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/input/__componentNameClass__InputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/output/__componentNameClass__OutputDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/output/__componentNameClass__OutputDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/output/__componentNameClass__OutputPropertiesTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-definition/src/test/java/definition/output/__componentNameClass__OutputPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-integration/src/test/java/integration/__componentNameClass__ComponentFamilyDefinitionTest.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-integration/src/test/java/integration/__componentNameClass__ComponentFamilyDefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-integration/src/test/java/integration/__componentNameClass__DatasetTestIT.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-integration/src/test/java/integration/__componentNameClass__DatasetTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__DatasetRuntime.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__DatasetRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__DatastoreRuntime.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__DatastoreRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__InputRuntime.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__InputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__OutputRuntime.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/main/java/runtime/__componentNameClass__OutputRuntime.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__DatasetRuntimeTestIT.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__DatasetRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__DatastoreRuntimeTestIT.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__DatastoreRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__InputRuntimeTestIT.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__InputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__OutputRuntimeTestIT.java
+++ b/examples/components-api-archetypes/bd-component-archetype/src/main/resources/archetype-resources/__componentNameLowerCase__-runtime/src/test/java/runtime/__componentNameClass__OutputRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/RuntimeInfoProvider.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/RuntimeInfoProvider.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/StringDelimiter.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/StringDelimiter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%${symbol_escape}features${symbol_escape}org.talend.rcp.branding.%PRODUCTNAME%${symbol_escape}%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentName__FamilyDefinition.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentName__FamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentPackage__/__componentName__Definition.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentPackage__/__componentName__Definition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentPackage__/__componentName__Properties.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/__componentPackage__/__componentName__Properties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/runtime/reader/SchemaDiscovery.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/main/java/runtime/reader/SchemaDiscovery.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/DisablablePaxExam.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/DisablablePaxExam.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/Osgi__componentName__TestIT.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/Osgi__componentName__TestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/Spring__componentName__TestIT.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/Spring__componentName__TestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentName__TestBase.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentName__TestBase.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentPackage__/__componentName__DefinitionTest.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentPackage__/__componentName__DefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentPackage__/__componentName__PropertiesTest.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-definition/src/test/java/__componentPackage__/__componentName__PropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/avro/DelimitedStringConverter.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/avro/DelimitedStringConverter.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/avro/DelimitedStringSchemaInferrer.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/avro/DelimitedStringSchemaInferrer.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/runtime/reader/__componentName__Reader.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/runtime/reader/__componentName__Reader.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/runtime/reader/__componentName__Source.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/main/java/runtime/reader/__componentName__Source.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/test/java/runtime/reader/__componentName__Test.java
+++ b/examples/components-api-archetypes/input-component-archetype/src/main/resources/archetype-resources/__rootArtifactId__-runtime/src/test/java/runtime/reader/__componentName__Test.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/main/java/definition/__componentNameLowerCase__/__componentNameClass__Definition.java
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/main/java/definition/__componentNameLowerCase__/__componentNameClass__Definition.java
@@ -2,7 +2,7 @@ package ${package}.definition.${componentNameLowerCase};
 
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/main/java/definition/__componentNameLowerCase__/__componentNameClass__Properties.java
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/main/java/definition/__componentNameLowerCase__/__componentNameClass__Properties.java
@@ -2,7 +2,7 @@ package ${package}.definition.${componentNameLowerCase};
 
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/test/java/definition/__componentNameLowerCase__/__componentNameClass__DefinitionTest.java
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/test/java/definition/__componentNameLowerCase__/__componentNameClass__DefinitionTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/test/java/definition/__componentNameLowerCase__/__componentNameClass__PropertiesTest.java
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-definition/src/test/java/definition/__componentNameLowerCase__/__componentNameClass__PropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/__componentNameClass__Runtime.java
+++ b/examples/components-api-archetypes/processing-bd-component-archetype/src/main/resources/archetype-resources/processing-runtime/src/main/java/runtime/__componentNameLowerCase__/__componentNameClass__Runtime.java
@@ -2,7 +2,7 @@ package ${package}.runtime.${componentNameLowerCase};
 
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleFamilyDefinition.java
+++ b/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleInputDefinition.java
+++ b/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleInputDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleProperties.java
+++ b/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/FullExampleProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/datastore/FullExampleDatastoreDefinition.java
+++ b/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/datastore/FullExampleDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/datastore/FullExampleDatastoreProperties.java
+++ b/examples/components-api-full-example/src/main/java/org/talend/components/fullexample/datastore/FullExampleDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-api-full-example/src/test/java/org/talend/components/fullexample/FullExamplePropertiesTest.java
+++ b/examples/components-api-full-example/src/test/java/org/talend/components/fullexample/FullExamplePropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentDefinition.java
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentFamilyDefinition.java
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentProperties.java
+++ b/examples/components-multiple-runtimes-and-deps/multiple-runtime-comp/src/main/java/org/talend/components/multiruntime/MultiRuntimeComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/src/main/java/org/talend/test/MyClass1.java
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib/src/main/java/org/talend/test/MyClass1.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/src/main/java/org/talend/test/MyClass2.java
+++ b/examples/components-multiple-runtimes-and-deps/same_libs_with_2_versions/zeLib_v2/src/main/java/org/talend/test/MyClass2.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/src/main/java/org/talend/multiruntime/MultiRuntimeComponentSource.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v01/src/main/java/org/talend/multiruntime/MultiRuntimeComponentSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/src/main/java/org/talend/multiruntime/MultiRuntimeComponentSource.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp-runtime_v02/src/main/java/org/talend/multiruntime/MultiRuntimeComponentSource.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/AbstractMultiRuntimeComponentTests.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/AbstractMultiRuntimeComponentTests.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/DisablablePaxExam.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/DisablablePaxExam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/MultiRuntimeComponentTest.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/MultiRuntimeComponentTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/MultiRuntimeTestIT.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/MultiRuntimeTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/SpringMultiRuntimeComponentTestIT.java
+++ b/examples/components-multiple-runtimes-and-deps/test-multiple-runtime-comp/src/test/java/org/talend/components/multiruntime/SpringMultiRuntimeComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/main/java/org/talend/components/api/service/common/ComponentServiceImpl.java
+++ b/services/components-api-service-common/src/main/java/org/talend/components/api/service/common/ComponentServiceImpl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/main/java/org/talend/components/api/service/common/DefinitionRegistry.java
+++ b/services/components-api-service-common/src/main/java/org/talend/components/api/service/common/DefinitionRegistry.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/ComponentServiceTest.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/ComponentServiceTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/DefintitionRegistryTest.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/DefintitionRegistryTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/ComponentPropertiesWithDefinedI18N.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/ComponentPropertiesWithDefinedI18N.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentDefinition.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentFamilyDefinition.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentInstaller.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentInstaller.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentProperties.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentWizard.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentWizard.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentWizardDefinition.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/TestComponentWizardDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestInjectComponentDefinition.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestInjectComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestInjectComponentProperties.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestInjectComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestNestedInjectComponentDefinition.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestNestedInjectComponentDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestNestedInjectComponentProperties.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/inject/TestNestedInjectComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/nestedprop/NestedComponentProperties.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/nestedprop/NestedComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/nestedprop/inherited/InheritedComponentProperties.java
+++ b/services/components-api-service-common/src/test/java/org/talend/components/api/service/common/testcomponent/nestedprop/inherited/InheritedComponentProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/context/osgi/GlobalContextOsgi.java
+++ b/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/context/osgi/GlobalContextOsgi.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/i18n/osgi/I18nMessageProviderOsgi.java
+++ b/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/i18n/osgi/I18nMessageProviderOsgi.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/i18n/osgi/LocaleProviderOsgi.java
+++ b/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/i18n/osgi/LocaleProviderOsgi.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/internal/osgi/ComponentServiceOsgi.java
+++ b/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/internal/osgi/ComponentServiceOsgi.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/internal/osgi/DefinitionRegistryOsgi.java
+++ b/services/components-api-service-osgi/src/main/java/org/talend/components/api/service/internal/osgi/DefinitionRegistryOsgi.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-osgi/src/test/java/org/talend/components/api/service/i18n/osgi/LocaleProviderOsgiTest.java
+++ b/services/components-api-service-osgi/src/test/java/org/talend/components/api/service/i18n/osgi/LocaleProviderOsgiTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest-all-components/src/test/java/org/talend/components/service/rest/SpringComponentTestIT.java
+++ b/services/components-api-service-rest-all-components/src/test/java/org/talend/components/service/rest/SpringComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest-all-components/src/test/java/org/talend/components/service/rest/TestApplication.java
+++ b/services/components-api-service-rest-all-components/src/test/java/org/talend/components/service/rest/TestApplication.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/Application.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/Application.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionType.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionType.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionTypeConverter.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionTypeConverter.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionsController.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/DefinitionsController.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/PropertiesController.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/PropertiesController.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/RuntimesController.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/RuntimesController.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/VersionController.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/VersionController.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ApiVersionConfig.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ApiVersionConfig.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ComponentsRegistrySetup.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ComponentsRegistrySetup.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ExceptionConvertionAspect.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/ExceptionConvertionAspect.java
@@ -1,5 +1,5 @@
 // ============================================================================
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/I18NSetup.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/configuration/I18NSetup.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ConnectorTypology.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ConnectorTypology.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ConnectorTypologyConverter.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ConnectorTypologyConverter.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/DefinitionDTO.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/DefinitionDTO.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/SerPropertiesDto.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/SerPropertiesDto.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/UiSpecsPropertiesDto.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/UiSpecsPropertiesDto.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ValidationResultDto.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ValidationResultDto.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ValidationResultsDto.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/ValidationResultsDto.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/VersionDto.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/dto/VersionDto.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/ApiError.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/ApiError.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/ControllersConfiguration.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/ControllersConfiguration.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/DatasetContentWriter.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/DatasetContentWriter.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/DefinitionsControllerImpl.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/DefinitionsControllerImpl.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesControllerImpl.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesControllerImpl.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesHelpers.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/PropertiesHelpers.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/RuntimeControllerImpl.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/RuntimeControllerImpl.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/UndefinedTriggerException.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/UndefinedTriggerException.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/VersionControllerImpl.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/impl/VersionControllerImpl.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/serialization/JsonSerializationHelper.java
+++ b/services/components-api-service-rest/src/main/java/org/talend/components/service/rest/serialization/JsonSerializationHelper.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/AbstractSpringIntegrationTests.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/AbstractSpringIntegrationTests.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/JdbcComponentTestIT.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/JdbcComponentTestIT.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/dto/ConnectorTypologyTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/dto/ConnectorTypologyTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleComponentTestIT.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleFamilyDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/FullExampleFamilyDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/dataset/FullExampleDatasetProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/datastore/FullExampleDatastoreDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/datastore/FullExampleDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/datastore/FullExampleDatastoreProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/fullexample/datastore/FullExampleDatastoreProperties.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/DataStoreServiceImplTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/DataStoreServiceImplTest.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/DefinitionsControllerTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/DefinitionsControllerTest.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/PropertiesControllerImplTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/PropertiesControllerImplTest.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/RuntimeControllerImplTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/RuntimeControllerImplTest.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/VersionControllerImplTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/impl/VersionControllerImplTest.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentDefinition.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentProperties.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentSinkProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentSinkProperties.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentSourceProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentSourceProperties.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentTransformerProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockComponentTransformerProperties.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetDefinition.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetProperties.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetRuntime.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatasetRuntime.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreDefinition.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreDefinition.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreProperties.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreProperties.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreRuntime.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/mock/MockDatastoreRuntime.java
@@ -1,6 +1,6 @@
 //==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/spring/SpringTestApp.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/spring/SpringTestApp.java
@@ -1,6 +1,6 @@
 // ==============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/services/components-api-service-spi/src/main/java/org/talend/components/service/spi/ServiceSpiFactory.java
+++ b/services/components-api-service-spi/src/main/java/org/talend/components/service/spi/ServiceSpiFactory.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Update copyright for all components classes.
Copyright year were inconsistent tried to align to 2006-2020.


**What is the new behavior?**
New 2020 year is used


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
