### PR TITLE
fix(TDI-41286): set default values

### DIFF
--- a/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDbTypeProperties.java
+++ b/components/components-snowflake/components-snowflake-definition/src/main/java/org/talend/components/snowflake/SnowflakeDbTypeProperties.java
@@ -82,6 +82,11 @@ public class SnowflakeDbTypeProperties extends ComponentPropertiesImpl  {
     public void setupProperties() {
         super.setupProperties();
         setFieldNames(Collections.EMPTY_LIST);
+
+        // to avoid setting of an exact first value in closed lists as a default value
+        // for more info TDI-41286 or\and ComponentsUtils#getParameterValue
+        column.setValue(Collections.emptyList());
+        dbtype.setValue(Collections.emptyList());
     }
 
     @Override

--- a/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputPropertiesTest.java
+++ b/components/components-snowflake/components-snowflake-definition/src/test/java/org/talend/components/snowflake/tsnowflakeoutput/TSnowflakeOutputPropertiesTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -27,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.talend.components.api.component.PropertyPathConnector;
 import org.talend.components.common.tableaction.TableAction;
-import org.talend.components.snowflake.SnowflakeDbTypeProperties;
 import org.talend.components.snowflake.tsnowflakeoutput.TSnowflakeOutputProperties.OutputAction;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
@@ -104,8 +104,8 @@ public class TSnowflakeOutputPropertiesTest {
         assertEquals(TableAction.TableActionEnum.NONE, tableAction);
 
         assertFalse(defaultUsePersonalDBType);
-        assertEquals(null, defaultDBTypeColumns);
-        assertEquals(null, defaultDBTypeType);
+        assertEquals(Collections.emptyList(), defaultDBTypeColumns);
+        assertEquals(Collections.emptyList(), defaultDBTypeType);
     }
 
     @Test


### PR DESCRIPTION
* set empty list as default value for the custom db types: column and dbtype properties

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-41286

**What is the new behavior?**
use an empty list as a default value instead of null value


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
