### PR TITLE
fix(TDI-44578) : dbType conf over dbType in schema

### DIFF
--- a/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLCreateTableAction.java
+++ b/core/components-common/src/main/java/org/talend/components/common/tableaction/DefaultSQLCreateTableAction.java
@@ -121,7 +121,6 @@ public class DefaultSQLCreateTableAction extends TableAction {
 
             String sDBLength = f.getProp(SchemaConstants.TALEND_COLUMN_DB_LENGTH);
             String sDBName = f.getProp(SchemaConstants.TALEND_COLUMN_DB_COLUMN_NAME);
-            String sDBType = f.getProp(SchemaConstants.TALEND_COLUMN_DB_TYPE);
             String sDBDefault = f.getProp(SchemaConstants.TALEND_COLUMN_DEFAULT);
             String sDBPrecision = f.getProp(SchemaConstants.TALEND_COLUMN_PRECISION);
             boolean sDBIsKey = Boolean.valueOf(f.getProp(SchemaConstants.TALEND_COLUMN_IS_KEY)).booleanValue();
@@ -134,9 +133,11 @@ public class DefaultSQLCreateTableAction extends TableAction {
             sb.append(escape(updateCaseIdentifier(name)));
             sb.append(" ");
 
+
+            String sDBType = this.getDbTypeMap().get(f.name());
+
             if(isNullOrEmpty(sDBType)){
-                // if SchemaConstants.TALEND_COLUMN_DB_TYPE not set, use given map
-                sDBType = this.getDbTypeMap().get(f.name());
+                sDBType = f.getProp(SchemaConstants.TALEND_COLUMN_DB_TYPE);
             }
 
             if (isNullOrEmpty(sDBType)) {
@@ -144,6 +145,7 @@ public class DefaultSQLCreateTableAction extends TableAction {
                 sDBType = convertAvroToSQL.convertToSQLTypeString(f.schema());
             }
             sb.append(updateCaseIdentifier(sDBType));
+
 
             buildLengthPrecision(sb, f, sDBType);
 

--- a/core/components-common/src/test/java/org/talend/components/common/tableaction/DefaultSQLCreateTableActionTest.java
+++ b/core/components-common/src/test/java/org/talend/components/common/tableaction/DefaultSQLCreateTableActionTest.java
@@ -72,6 +72,55 @@ public class DefaultSQLCreateTableActionTest {
     }
 
     @Test
+    public void createTableWithDbTypeInProp() {
+
+        // Enforce dbType in field prop
+        this.schema.getField("date").addProp(SchemaConstants.TALEND_COLUMN_DB_TYPE, "VARCHAR");
+
+        DefaultSQLCreateTableAction action =
+                new DefaultSQLCreateTableAction(new String[] { "MyTable" }, schema, false, false, false);
+        TableActionConfig conf = new TableActionConfig();
+        conf.SQL_ESCAPE_ENABLED = false;
+        action.setConfig(conf);
+        try {
+            List<String> queries = action.getQueries();
+            assertEquals(1, queries.size());
+            assertEquals(
+                    "CREATE TABLE MyTable (id INTEGER, name VARCHAR(255) DEFAULT \"ok\", date VARCHAR, salary MY_DOUBLE(38, 4), updated TIMESTAMP, CONSTRAINT pk_MyTable PRIMARY KEY (id, name))",
+                    queries.get(0));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void createTableWithDbTypeConfOverSchema() {
+
+        // Enforce dbType in field prop
+        this.schema.getField("date").addProp(SchemaConstants.TALEND_COLUMN_DB_TYPE, "VARCHAR");
+
+        DefaultSQLCreateTableAction action =
+                new DefaultSQLCreateTableAction(new String[] { "MyTable" }, schema, false, false, false);
+        TableActionConfig conf = new TableActionConfig();
+        conf.SQL_ESCAPE_ENABLED = false;
+        action.setConfig(conf);
+
+        Map dbTypMap = new HashMap();
+        dbTypMap.put("date", "MyOwnDbType");
+        action.setDbTypeMap(dbTypMap);
+
+        try {
+            List<String> queries = action.getQueries();
+            assertEquals(1, queries.size());
+            assertEquals(
+                    "CREATE TABLE MyTable (id INTEGER, name VARCHAR(255) DEFAULT \"ok\", date MyOwnDbType, salary MY_DOUBLE(38, 4), updated TIMESTAMP, CONSTRAINT pk_MyTable PRIMARY KEY (id, name))",
+                    queries.get(0));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     public void createTableIfNotExists() {
         DefaultSQLCreateTableAction action =
                 new DefaultSQLCreateTableAction(new String[] { "MyTable" }, schema, true, false, false);


### PR DESCRIPTION
What is the current behavior? (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44578

What is the new behavior?
First the dbType used is first the one from advanced settings, then after the one from studio schema (shuld be empty for tcompV0, but we have the in migration it seems).



**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
