### PR TITLE
fix(TDI-36042): Friendly connection error message

### DIFF
--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.java
@@ -216,7 +216,12 @@ public class SalesforceSourceOrSink implements SalesforceRuntimeSourceOrSink, Sa
      */
     private void performLogin(ConnectorConfig config, PartnerConnection connection) throws ConnectionException {
         config.setServiceEndpoint(config.getAuthEndpoint());
-        LoginResult loginResult = connection.login(config.getUsername(), config.getPassword());
+        LoginResult loginResult = null;
+        try {
+            loginResult = connection.login(config.getUsername(), config.getPassword());
+        }catch (ConnectionException e){
+            throw new ConnectionException(MESSAGES.getMessage("error.connectionFail"));
+        }
         if (loginResult.isPasswordExpired()) {
             throw new ConnectionException(MESSAGES.getMessage("error.expiredPassword"));
         }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/resources/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.properties
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/resources/org/talend/components/salesforce/runtime/SalesforceSourceOrSink.properties
@@ -1,1 +1,2 @@
 error.expiredPassword=Your password has been expired. Please set up a new password before continue.
+error.connectionFail=Connection was not created, invalid credentials or user locked out.


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
previously there was an weird message. https://jira.talendforge.org/browse/TDI-36042 


**What is the new behavior?**
The message is user-friendly now.
works well in TOS_DI-20210101_1939-V7.4.1 with components-parent version0.29.0-SNAPSHOT

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Was added the try/catch block in the SalesforceSourceOrSink and error.connectionFail in the properties. Have no idea why the error.expiredPassword was deleted and added again it was not being touched.
