### PR TITLE
fix(TDI-45526):tSalesforceOutputBulkExec using Bulk V2 crashes when zero

### DIFF
--- a/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReaderTestIT.java
+++ b/components/components-salesforce/components-salesforce-integration/src/test/java/org/talend/components/salesforce/runtime/SalesforceBulkExecReaderTestIT.java
@@ -112,6 +112,12 @@ public class SalesforceBulkExecReaderTestIT extends SalesforceTestBase {
     }
 
     @Test
+    @Ignore("need manual operation for oauth login")
+    public void testBulkV2EmptySource() throws Throwable {
+        testOutputBulkExec(0, true);
+    }
+
+    @Test
     public void testOutputBulkExecV1Reject() throws Throwable {
         testOutputBulkExecReject(false);
     }

--- a/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkV2ExecReader.java
+++ b/components/components-salesforce/components-salesforce-runtime/src/main/java/org/talend/components/salesforce/runtime/SalesforceBulkV2ExecReader.java
@@ -71,6 +71,9 @@ final class SalesforceBulkV2ExecReader extends SalesforceReader {
         bulkRuntime = new SalesforceBulkV2Runtime(bulkV2Conn, sprops);
         try {
             bulkRuntime.executeBulk();
+            if (bulkRuntime.getNumberRecordsProcessed() <= 0) {
+                return false;
+            }
             return retrieveResultSet();
         } catch (InterruptedException e) {
             throw new IOException(e);


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

For JIRA: https://jira.talendforge.org/browse/TDI-45526

**What is the new behavior?**



**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
