### PR TITLE
fix(TDI-47935): bump "nimbus-jose-jwt" lib to fix CVE.

### DIFF
--- a/components-parent/components-bom/pom.xml
+++ b/components-parent/components-bom/pom.xml
@@ -158,7 +158,7 @@
         <netty4.version>4.1.75.Final</netty4.version>
         <netty-tcnative-boringssl-static.version>1.1.33.Fork26</netty-tcnative-boringssl-static.version>
         <netty.version>3.10.6.Final</netty.version>
-        <nimbus-jose-jwt.version>8.11</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.22</nimbus-jose-jwt.version>
         <okio.version>1.14.0</okio.version>
         <org.codehaus.janino.commons-compiler.version>${org.codehaus.janino.version}</org.codehaus.janino.commons-compiler.version>
         <org.codehaus.janino.janino.version>${org.codehaus.janino.version}</org.codehaus.janino.janino.version>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-47935


**What is the new behavior?**



**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [X] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [X] Other... Please describe: CVE task.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Backport of https://github.com/Talend/components/pull/2079 into "maintenance/8.0" branch.