### PR TITLE
fix(TDP-11227): change default mgmt port to an unused one

### DIFF
--- a/services/components-api-service-rest/src/main/resources/application.properties
+++ b/services/components-api-service-rest/src/main/resources/application.properties
@@ -23,7 +23,7 @@ logging.level.root=${LOGGING_LEVEL:INFO}
 # Actuator
 ##
 # Comment out the line below to use a dedicated port than server port for management probe
-# management.server.port=9000
+# management.server.port=9700
 #
 # Add a tag in each metric returned by Actuator
 management.metrics.tags.app=tcomp


### PR DESCRIPTION
Even if the management probe is by default running on the same port as the application, the user can choose to comment out the configuration parameter and use a different port.

The default port chosen was `9000`, which was already used by another component of the TDP on-prem install. So, let's switch to an unused one.