### PR TITLE
fix(TDP-11718): [On-prem 8] Fix tcomp service when using java 17 at runtime

### DIFF
--- a/services/components-api-service-rest/scripts/start.bat
+++ b/services/components-api-service-rest/scripts/start.bat
@@ -17,4 +17,23 @@ SET PATH=%PATH%;%HADOOP_HOME%\bin
 
 IF NOT DEFINED OPS4J_PAX_OPTS SET OPS4J_PAX_OPTS=-Dorg.ops4j.pax.url.mvn.useFallbackRepositories=false
 
+REM Check java major version to add some required options for java >=9
+SET JAVA_VERSION=0
+FOR /f "tokens=3" %%g IN ('java -version 2^>^&1 ^| findstr /i "version"') DO (
+  SET JAVA_VERSION=%%g
+)
+SET JAVA_VERSION=%JAVA_VERSION:"=%
+FOR /f "delims=.-_ tokens=1-2" %%v IN ("%JAVA_VERSION%") DO (
+  IF /I "%%v" EQU "1" (
+    SET JAVA_VERSION=%%w
+  ) ELSE (
+    SET JAVA_VERSION=%%v
+  )
+)
+
+IF %JAVA_VERSION% GEQ 9 (
+    SET JAVA_OPTS=%JAVA_OPTS% --add-opens java.base/java.net=ALL-UNNAMED
+)
+
+
 java %JAVA_OPTS% %OPS4J_PAX_OPTS% -Xmx2048m -Dfile.encoding=UTF-8 -Dorg.ops4j.pax.url.mvn.localRepository="%THISDIR%\.m2" -Dorg.ops4j.pax.url.mvn.settings="%THISDIR%config\settings.xml" -Dcomponent.default.config.folder="%THISDIR%\config\default" -cp %CLASSPATH% %APP_CLASS%

--- a/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/configuration/ComponentsRegistrySetupTest.java
+++ b/services/components-api-service-rest/src/test/java/org/talend/components/service/rest/configuration/ComponentsRegistrySetupTest.java
@@ -3,7 +3,10 @@ package org.talend.components.service.rest.configuration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 
+import java.net.URL;
+
 import org.junit.Test;
+import org.talend.components.api.component.runtime.JarRuntimeInfo;
 
 public class ComponentsRegistrySetupTest {
 
@@ -21,5 +24,16 @@ public class ComponentsRegistrySetupTest {
     }
 
     // TODO need more tests on the createDefinitionRegistry
+
+    @Test
+    // Add "--add-opens java.base/java.net=ALL-UNNAMED" option to JVM to run this test with java 17
+    public void testExtractComponentsUrlsWithMavenProtocol() {
+        ComponentsRegistrySetup registrySetup = new ComponentsRegistrySetup();
+        new JarRuntimeInfo((URL) null, null, null); // ensure mvn url -
+
+        // checking with working URL
+        assertThat(registrySetup.extractComponentsUrls(
+                "mvn:org.talend.components/components-jdbc-definition/0.28.18-SNAPSHOT/jar"), arrayWithSize(1));
+    }
 
 }


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
TCOMP service can't be used with java 17 (https://jira.talendforge.org/browse/TDP-11718)
There are errors when loading components list definitions


**What is the new behavior?**
Loading components list definitions is fixed


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
